### PR TITLE
feat: split osv requests and increase timeout

### DIFF
--- a/src/main/java/com/redhat/exhort/integration/providers/tpa/TpaIntegration.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/tpa/TpaIntegration.java
@@ -43,7 +43,7 @@ public class TpaIntegration extends EndpointRouteBuilder {
   private static final String TPA_CLIENT_TENANT = "tpa";
   private static final int TPA_CLIENT_TIMEOUT = 10;
 
-  @ConfigProperty(name = "api.tpa.timeout", defaultValue = "30s")
+  @ConfigProperty(name = "api.tpa.timeout", defaultValue = "60s")
   String timeout;
 
   @ConfigProperty(name = "quarkus.oidc-client.tpa.enabled", defaultValue = "true")


### PR DESCRIPTION
Increases the timeout for ONguard and TPA to allow big SBOMs to complete. Sometimes the OSV API is slower and requires more time.
For the same reason splitting ONguard requests into batches increases concurrency and reduces the time for processing.

Fix [TC-2798](https://issues.redhat.com/browse/TC-2798)