### PR TITLE
chore: update license header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
   <name>RHDA - Exhort</name>
   <licenses>
     <license>
-      <name>Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <name>Apache-2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>
   </licenses>

--- a/src/license/java_header.txt
+++ b/src/license/java_header.txt
@@ -1,6 +1,5 @@
 /*
- * Copyright $YEAR Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/config/CustomReflectionConfiguration.java
+++ b/src/main/java/com/redhat/exhort/config/CustomReflectionConfiguration.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/config/ObjectMapperProducer.java
+++ b/src/main/java/com/redhat/exhort/config/ObjectMapperProducer.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/config/exception/ClientDetailedException.java
+++ b/src/main/java/com/redhat/exhort/config/exception/ClientDetailedException.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/config/exception/CycloneDXValidationException.java
+++ b/src/main/java/com/redhat/exhort/config/exception/CycloneDXValidationException.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/config/exception/DetailedException.java
+++ b/src/main/java/com/redhat/exhort/config/exception/DetailedException.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/config/exception/PackageValidationException.java
+++ b/src/main/java/com/redhat/exhort/config/exception/PackageValidationException.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/config/exception/SbomValidationException.java
+++ b/src/main/java/com/redhat/exhort/config/exception/SbomValidationException.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/config/exception/SpdxValidationException.java
+++ b/src/main/java/com/redhat/exhort/config/exception/SpdxValidationException.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/config/exception/UnexpectedProviderException.java
+++ b/src/main/java/com/redhat/exhort/config/exception/UnexpectedProviderException.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/config/metrics/CustomMetrics.java
+++ b/src/main/java/com/redhat/exhort/config/metrics/CustomMetrics.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/Constants.java
+++ b/src/main/java/com/redhat/exhort/integration/Constants.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/backend/BackendUtils.java
+++ b/src/main/java/com/redhat/exhort/integration/backend/BackendUtils.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/backend/ExhortIntegration.java
+++ b/src/main/java/com/redhat/exhort/integration/backend/ExhortIntegration.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/cache/CacheService.java
+++ b/src/main/java/com/redhat/exhort/integration/cache/CacheService.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/cache/RedisCacheService.java
+++ b/src/main/java/com/redhat/exhort/integration/cache/RedisCacheService.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/modelcards/ModelCardIntegration.java
+++ b/src/main/java/com/redhat/exhort/integration/modelcards/ModelCardIntegration.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/providers/ProviderAggregationStrategy.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/ProviderAggregationStrategy.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/providers/ProviderHealthCheckManager.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/ProviderHealthCheckManager.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/providers/ProviderResponseHandler.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/ProviderResponseHandler.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/providers/VulnerabilityProvider.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/VulnerabilityProvider.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/providers/osv/OsvIntegration.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/osv/OsvIntegration.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/providers/osv/OsvRequestBuilder.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/osv/OsvRequestBuilder.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/providers/osv/OsvResponseHandler.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/osv/OsvResponseHandler.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/providers/trustify/ProviderRoutePolicy.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/trustify/ProviderRoutePolicy.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/providers/trustify/TrustifyIntegration.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/trustify/TrustifyIntegration.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/providers/trustify/TrustifyRequestBuilder.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/trustify/TrustifyRequestBuilder.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/providers/trustify/TrustifyResponseHandler.java
+++ b/src/main/java/com/redhat/exhort/integration/providers/trustify/TrustifyResponseHandler.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/report/ReportIntegration.java
+++ b/src/main/java/com/redhat/exhort/integration/report/ReportIntegration.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/report/ReportTemplate.java
+++ b/src/main/java/com/redhat/exhort/integration/report/ReportTemplate.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/report/ReportTransformer.java
+++ b/src/main/java/com/redhat/exhort/integration/report/ReportTransformer.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/sbom/SbomParser.java
+++ b/src/main/java/com/redhat/exhort/integration/sbom/SbomParser.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/sbom/SbomParserFactory.java
+++ b/src/main/java/com/redhat/exhort/integration/sbom/SbomParserFactory.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/sbom/cyclonedx/CycloneDxParser.java
+++ b/src/main/java/com/redhat/exhort/integration/sbom/cyclonedx/CycloneDxParser.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/sbom/spdx/SpdxParser.java
+++ b/src/main/java/com/redhat/exhort/integration/sbom/spdx/SpdxParser.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/sbom/spdx/SpdxWrapper.java
+++ b/src/main/java/com/redhat/exhort/integration/sbom/spdx/SpdxWrapper.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/trustedcontent/TcResponseAggregation.java
+++ b/src/main/java/com/redhat/exhort/integration/trustedcontent/TcResponseAggregation.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/trustedcontent/TcResponseHandler.java
+++ b/src/main/java/com/redhat/exhort/integration/trustedcontent/TcResponseHandler.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/trustedcontent/TrustedContentIntegration.java
+++ b/src/main/java/com/redhat/exhort/integration/trustedcontent/TrustedContentIntegration.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/trustedcontent/TrustedContentRequestBuilder.java
+++ b/src/main/java/com/redhat/exhort/integration/trustedcontent/TrustedContentRequestBuilder.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/integration/trustedcontent/ubi/UBIRecommendation.java
+++ b/src/main/java/com/redhat/exhort/integration/trustedcontent/ubi/UBIRecommendation.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/CvssParser.java
+++ b/src/main/java/com/redhat/exhort/model/CvssParser.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/CvssScoreComparable.java
+++ b/src/main/java/com/redhat/exhort/model/CvssScoreComparable.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/DependencyTree.java
+++ b/src/main/java/com/redhat/exhort/model/DependencyTree.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/DirectDependency.java
+++ b/src/main/java/com/redhat/exhort/model/DirectDependency.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/ProviderHealthCheckResult.java
+++ b/src/main/java/com/redhat/exhort/model/ProviderHealthCheckResult.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/ProviderResponse.java
+++ b/src/main/java/com/redhat/exhort/model/ProviderResponse.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/modelcards/Guardrail.java
+++ b/src/main/java/com/redhat/exhort/model/modelcards/Guardrail.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/modelcards/GuardrailScope.java
+++ b/src/main/java/com/redhat/exhort/model/modelcards/GuardrailScope.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/modelcards/ModelCardConfig.java
+++ b/src/main/java/com/redhat/exhort/model/modelcards/ModelCardConfig.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/modelcards/ModelCardReport.java
+++ b/src/main/java/com/redhat/exhort/model/modelcards/ModelCardReport.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/modelcards/ModelCardTask.java
+++ b/src/main/java/com/redhat/exhort/model/modelcards/ModelCardTask.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/modelcards/TaskDefinition.java
+++ b/src/main/java/com/redhat/exhort/model/modelcards/TaskDefinition.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/modelcards/TaskMetric.java
+++ b/src/main/java/com/redhat/exhort/model/modelcards/TaskMetric.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/modelcards/Threshold.java
+++ b/src/main/java/com/redhat/exhort/model/modelcards/Threshold.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/trustedcontent/CachedRecommendation.java
+++ b/src/main/java/com/redhat/exhort/model/trustedcontent/CachedRecommendation.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/trustedcontent/IndexedRecommendation.java
+++ b/src/main/java/com/redhat/exhort/model/trustedcontent/IndexedRecommendation.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/trustedcontent/Recommendations.java
+++ b/src/main/java/com/redhat/exhort/model/trustedcontent/Recommendations.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/trustedcontent/TcRecommendation.java
+++ b/src/main/java/com/redhat/exhort/model/trustedcontent/TcRecommendation.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/trustedcontent/TrustedContentCachedRequest.java
+++ b/src/main/java/com/redhat/exhort/model/trustedcontent/TrustedContentCachedRequest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/trustedcontent/TrustedContentResponse.java
+++ b/src/main/java/com/redhat/exhort/model/trustedcontent/TrustedContentResponse.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/trustedcontent/Vulnerability.java
+++ b/src/main/java/com/redhat/exhort/model/trustedcontent/Vulnerability.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/trustify/AdvisoryScore.java
+++ b/src/main/java/com/redhat/exhort/model/trustify/AdvisoryScore.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/trustify/ProviderAuthConfig.java
+++ b/src/main/java/com/redhat/exhort/model/trustify/ProviderAuthConfig.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/trustify/ProviderConfig.java
+++ b/src/main/java/com/redhat/exhort/model/trustify/ProviderConfig.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/trustify/ProvidersConfig.java
+++ b/src/main/java/com/redhat/exhort/model/trustify/ProvidersConfig.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/model/trustify/ScoreType.java
+++ b/src/main/java/com/redhat/exhort/model/trustify/ScoreType.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/modelcards/GuardrailRepository.java
+++ b/src/main/java/com/redhat/exhort/modelcards/GuardrailRepository.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/modelcards/ModelCardRepository.java
+++ b/src/main/java/com/redhat/exhort/modelcards/ModelCardRepository.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/modelcards/ModelCardService.java
+++ b/src/main/java/com/redhat/exhort/modelcards/ModelCardService.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/modelcards/TaskDefinitionRepository.java
+++ b/src/main/java/com/redhat/exhort/modelcards/TaskDefinitionRepository.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/monitoring/MonitoringClient.java
+++ b/src/main/java/com/redhat/exhort/monitoring/MonitoringClient.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/monitoring/MonitoringClientFactory.java
+++ b/src/main/java/com/redhat/exhort/monitoring/MonitoringClientFactory.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/monitoring/MonitoringContext.java
+++ b/src/main/java/com/redhat/exhort/monitoring/MonitoringContext.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/monitoring/MonitoringProcessor.java
+++ b/src/main/java/com/redhat/exhort/monitoring/MonitoringProcessor.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/monitoring/SentryMonitoringClientFactory.java
+++ b/src/main/java/com/redhat/exhort/monitoring/SentryMonitoringClientFactory.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/monitoring/impl/NoopMonitoringClient.java
+++ b/src/main/java/com/redhat/exhort/monitoring/impl/NoopMonitoringClient.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/monitoring/impl/SentryMonitoringClient.java
+++ b/src/main/java/com/redhat/exhort/monitoring/impl/SentryMonitoringClient.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/redhat/exhort/service/DynamicOidcClientService.java
+++ b/src/main/java/com/redhat/exhort/service/DynamicOidcClientService.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/extensions/InjectWireMock.java
+++ b/src/test/java/com/redhat/exhort/extensions/InjectWireMock.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/extensions/OidcWiremockExtension.java
+++ b/src/test/java/com/redhat/exhort/extensions/OidcWiremockExtension.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/extensions/WiremockExtension.java
+++ b/src/test/java/com/redhat/exhort/extensions/WiremockExtension.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/AbstractAnalysisTest.java
+++ b/src/test/java/com/redhat/exhort/integration/AbstractAnalysisTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/AnalysisIT.java
+++ b/src/test/java/com/redhat/exhort/integration/AnalysisIT.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/AnalysisTest.java
+++ b/src/test/java/com/redhat/exhort/integration/AnalysisTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/HtmlReportTest.java
+++ b/src/test/java/com/redhat/exhort/integration/HtmlReportTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/TokenValidationIT.java
+++ b/src/test/java/com/redhat/exhort/integration/TokenValidationIT.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/TokenValidationTest.java
+++ b/src/test/java/com/redhat/exhort/integration/TokenValidationTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/backend/BackendUtilsTest.java
+++ b/src/test/java/com/redhat/exhort/integration/backend/BackendUtilsTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/backend/sbom/SbomParserTest.java
+++ b/src/test/java/com/redhat/exhort/integration/backend/sbom/SbomParserTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/backend/sbom/SpdxWrapperTest.java
+++ b/src/test/java/com/redhat/exhort/integration/backend/sbom/SpdxWrapperTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/backend/sbom/cyclonedx/CycloneDxParserTest.java
+++ b/src/test/java/com/redhat/exhort/integration/backend/sbom/cyclonedx/CycloneDxParserTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/cache/RedisCacheServiceTest.java
+++ b/src/test/java/com/redhat/exhort/integration/cache/RedisCacheServiceTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/modelcards/ModelCardIntegrationTest.java
+++ b/src/test/java/com/redhat/exhort/integration/modelcards/ModelCardIntegrationTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/providers/ProviderResponseHandlerTest.java
+++ b/src/test/java/com/redhat/exhort/integration/providers/ProviderResponseHandlerTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/providers/osv/OsvResponseHandlerTest.java
+++ b/src/test/java/com/redhat/exhort/integration/providers/osv/OsvResponseHandlerTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/providers/trustify/TrustifyResponseHandlerTest.java
+++ b/src/test/java/com/redhat/exhort/integration/providers/trustify/TrustifyResponseHandlerTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/trustedcontent/TcResponseHandlerTest.java
+++ b/src/test/java/com/redhat/exhort/integration/trustedcontent/TcResponseHandlerTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/integration/trustedcontent/TrustedContentRequestBuilderTest.java
+++ b/src/test/java/com/redhat/exhort/integration/trustedcontent/TrustedContentRequestBuilderTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2024 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/model/CvssParserTest.java
+++ b/src/test/java/com/redhat/exhort/model/CvssParserTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2023 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/redhat/exhort/modelcards/ModelCardServiceTest.java
+++ b/src/test/java/com/redhat/exhort/modelcards/ModelCardServiceTest.java
@@ -1,6 +1,5 @@
 /*
- * Copyright 2025 Red Hat, Inc. and/or its affiliates
- * and other contributors as indicated by the @author tags.
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
fixes: https://github.com/guacsec/trustify-dependency-analytics/issues/506 

chore: update license header