### PR TITLE
fix: ignore withdrawn vulnerabilies

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandler.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandler.java
@@ -126,6 +126,9 @@ public class TrustifyResponseHandler extends ProviderResponseHandler {
 
           affected.forEach(
               data -> {
+                if (data.hasNonNull("withdrawn")) {
+                  return;
+                }
                 var source = getSource(data);
                 if (source == null) {
                   return;

--- a/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandlerTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandlerTest.java
@@ -358,6 +358,26 @@ public class TrustifyResponseHandlerTest {
                             "severity": "medium"
                           }
                         ]
+                      },
+                      {
+                        "uuid": "urn:uuid:595a7085-f230-42b5-9c8f-ab25939d9908",
+                        "identifier": "CVE-2022-41946",
+                        "document_id": "CVE-2022-41946",
+                        "title": "This CVE is a placeholder for a vulnerability that has been withdrawn",
+                        "withdrawn": "2024-01-01T00:00:00Z",
+                        "labels": {
+                          "type": "osv",
+                          "file": "github-reviewed/2022/11/GHSA-562r-vg33-8x8h/GHSA-562r-vg33-8x8h.json",
+                          "importer": "osv-github",
+                          "source": "https://github.com/github/advisory-database"
+                        },
+                        "scores": [
+                          {
+                            "type": "3.1",
+                            "value": 5.8,
+                            "severity": "medium"
+                          }
+                        ]
                       }
                     ]
                   }


### PR DESCRIPTION
### **User description**
Fix #564


___

### **PR Type**
Bug fix


___

### **Description**
- Filter out vulnerabilities with withdrawn field

- Add test case for withdrawn vulnerability handling

- Prevent processing of withdrawn CVE records


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Trustify Response"] --> B["Check for withdrawn field"]
  B -->|withdrawn exists| C["Skip vulnerability"]
  B -->|no withdrawn field| D["Process normally"]
  D --> E["Return Issues"]
  C --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TrustifyResponseHandler.java</strong><dd><code>Skip withdrawn vulnerabilities in response processing</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandler.java

<ul><li>Added check to skip vulnerabilities with non-null <code>withdrawn</code> field<br> <li> Early return prevents processing of withdrawn CVE records<br> <li> Maintains existing status validation logic</ul>


</details>


  </td>
  <td><a href="https://github.com/guacsec/trustify-dependency-analytics/pull/565/files#diff-c452268cf00b6ecf5c032b2b0614867a43a719de8028463a4b562e4327c243d6">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TrustifyResponseHandlerTest.java</strong><dd><code>Add test case for withdrawn vulnerability filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandlerTest.java

<ul><li>Added comprehensive test case with withdrawn vulnerability response<br> <li> Includes withdrawn CVE-2022-41948 with timestamp<br> <li> Tests alongside valid vulnerabilities CVE-2022-41946 and CVE-2024-1597<br> <li> Validates that withdrawn vulnerabilities are properly filtered</ul>


</details>


  </td>
  <td><a href="https://github.com/guacsec/trustify-dependency-analytics/pull/565/files#diff-e73cdc8442d70727671ca620e9253a654c72ae22cf110323e1009ad96407cb55">+134/-1</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

