### PR TITLE
feat: limit validation to minimum required data

### DIFF
--- a/src/test/java/io/github/guacsec/trustifyda/integration/AnalysisTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/AnalysisTest.java
@@ -139,7 +139,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
 
     switch (sbom) {
       case CYCLONEDX -> assertTrue(response.startsWith("CycloneDX Validation"));
-      case SPDX -> assertTrue(response.startsWith("SPDX-2.3 Validation"));
+      case SPDX -> assertTrue(response.startsWith("SPDX Validation"));
     }
 
     verifyNoInteractions();
@@ -530,7 +530,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
 
     switch (sbom) {
       case CYCLONEDX -> assertTrue(response.startsWith("CycloneDX Validation"));
-      case SPDX -> assertTrue(response.startsWith("SPDX-2.3 Validation"));
+      case SPDX -> assertTrue(response.startsWith("SPDX Validation"));
     }
   }
 

--- a/src/test/java/io/github/guacsec/trustifyda/integration/backend/sbom/SpdxWrapperTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/backend/sbom/SpdxWrapperTest.java
@@ -19,8 +19,10 @@ package io.github.guacsec.trustifyda.integration.backend.sbom;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,6 +34,8 @@ import io.github.guacsec.trustifyda.config.exception.SpdxValidationException;
 import io.github.guacsec.trustifyda.integration.sbom.spdx.SpdxWrapper;
 
 public class SpdxWrapperTest {
+
+  private static final String VALIDATION_ERRORS_BASE = "spdx/validation-errors/";
 
   @ParameterizedTest
   @ValueSource(strings = {Version.TWO_POINT_THREE_VERSION, Version.TWO_POINT_TWO_VERSION})
@@ -57,5 +61,62 @@ public class SpdxWrapperTest {
                         .getClassLoader()
                         .getResourceAsStream("cyclonedx/empty-sbom.json")));
     assertNotNull(err.getMessage());
+  }
+
+  @Test
+  void testPackagesWithoutPurlAreSkipped() throws Exception {
+    // Packages without a PURL cannot be analyzed; they are skipped (no validation error)
+    var wrapper = new SpdxWrapper(stream(VALIDATION_ERRORS_BASE + "spdx-2.3-missing-purl.json"));
+    assertNotNull(wrapper.getStartFromPackages());
+    assertNotNull(wrapper.getRelationships());
+    // When all direct deps are skipped, startFrom is empty (same as no-deps SBOM, aligned with
+    // CycloneDX)
+  }
+
+  @Test
+  void testPackagesWithEmptyPurlLocatorAreSkipped() throws Exception {
+    var wrapper =
+        new SpdxWrapper(stream(VALIDATION_ERRORS_BASE + "spdx-2.3-empty-purl-locator.json"));
+    assertNotNull(wrapper.getStartFromPackages());
+    assertNotNull(wrapper.getRelationships());
+  }
+
+  @Test
+  void testValidationErrorInvalidRelationship() {
+    var err =
+        assertThrows(
+            SpdxValidationException.class,
+            () ->
+                new SpdxWrapper(
+                    stream(VALIDATION_ERRORS_BASE + "spdx-2.3-invalid-relationship.json")));
+    assertNotNull(err.getMessage());
+    assertTrue(
+        err.getDetails() != null
+            && (err.getDetails().contains("SPDXRef-Nonexistent")
+                || err.getDetails().contains("not in this document")),
+        "Expected aggregated errors to mention invalid relationship, got: " + err.getDetails());
+  }
+
+  @Test
+  void testMultiplePackagesWithoutPurlAreSkipped() throws Exception {
+    // Multiple packages missing PURL or with empty PURL are all skipped; parse succeeds
+    var wrapper = new SpdxWrapper(stream(VALIDATION_ERRORS_BASE + "spdx-2.3-multiple-errors.json"));
+    assertNotNull(wrapper.getStartFromPackages());
+    assertNotNull(wrapper.getRelationships());
+  }
+
+  @Test
+  void testDuplicatePackagesCachedProperly() throws Exception {
+    // Test that packages referenced multiple times are cached and not processed repeatedly
+    var wrapper =
+        new SpdxWrapper(stream(VALIDATION_ERRORS_BASE + "spdx-2.3-duplicate-packages.json"));
+    assertNotNull(wrapper.getStartFromPackages());
+    assertNotNull(wrapper.getRelationships());
+    // The same package SPDXRef-Duplicate appears in multiple relationships
+    // Caching should prevent re-processing the same package multiple times
+  }
+
+  private static InputStream stream(String resource) {
+    return SpdxWrapperTest.class.getClassLoader().getResourceAsStream(resource);
   }
 }

--- a/src/test/resources/spdx/validation-errors/spdx-2.3-duplicate-packages.json
+++ b/src/test/resources/spdx/validation-errors/spdx-2.3-duplicate-packages.json
@@ -1,0 +1,70 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "spdxVersion": "SPDX-2.3",
+  "creationInfo": {
+    "created": "2023-01-01T00:00:00Z",
+    "creators": ["Tool: Test-1.0"],
+    "licenseListVersion": "3.21"
+  },
+  "name": "test-duplicate-packages",
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://test.example.com/duplicate-packages",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Root",
+      "name": "root-package",
+      "versionInfo": "1.0",
+      "downloadLocation": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/org/root@1.0",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Duplicate",
+      "name": "duplicate-package",
+      "versionInfo": "1.0",
+      "downloadLocation": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/org/duplicate@1.0",
+          "referenceType": "purl"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Root"
+    },
+    {
+      "spdxElementId": "SPDXRef-Root",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Duplicate"
+    },
+    {
+      "spdxElementId": "SPDXRef-Root",
+      "relationshipType": "CONTAINS",
+      "relatedSpdxElement": "SPDXRef-Duplicate"
+    },
+    {
+      "spdxElementId": "SPDXRef-Duplicate",
+      "relationshipType": "DEPENDENCY_OF",
+      "relatedSpdxElement": "SPDXRef-Root"
+    }
+  ]
+}

--- a/src/test/resources/spdx/validation-errors/spdx-2.3-empty-purl-locator.json
+++ b/src/test/resources/spdx/validation-errors/spdx-2.3-empty-purl-locator.json
@@ -1,0 +1,60 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "spdxVersion": "SPDX-2.3",
+  "creationInfo": {
+    "created": "2023-01-01T00:00:00Z",
+    "creators": ["Tool: Test-1.0"],
+    "licenseListVersion": "3.21"
+  },
+  "name": "test-empty-purl-locator",
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://test.example.com/empty-purl",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Root",
+      "name": "root-package",
+      "versionInfo": "1.0",
+      "downloadLocation": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/org/root@1.0",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-EmptyPurl",
+      "name": "package-empty-purl",
+      "versionInfo": "2.0",
+      "downloadLocation": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "",
+          "referenceType": "purl"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Root"
+    },
+    {
+      "spdxElementId": "SPDXRef-Root",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-EmptyPurl"
+    }
+  ]
+}

--- a/src/test/resources/spdx/validation-errors/spdx-2.3-invalid-relationship.json
+++ b/src/test/resources/spdx/validation-errors/spdx-2.3-invalid-relationship.json
@@ -1,0 +1,43 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "spdxVersion": "SPDX-2.3",
+  "creationInfo": {
+    "created": "2023-01-01T00:00:00Z",
+    "creators": ["Tool: Test-1.0"],
+    "licenseListVersion": "3.21"
+  },
+  "name": "test-invalid-relationship",
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://test.example.com/invalid-relationship",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Root",
+      "name": "root-package",
+      "versionInfo": "1.0",
+      "downloadLocation": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/org/root@1.0",
+          "referenceType": "purl"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Root"
+    },
+    {
+      "spdxElementId": "SPDXRef-Root",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Nonexistent"
+    }
+  ]
+}

--- a/src/test/resources/spdx/validation-errors/spdx-2.3-malformed-uri.json
+++ b/src/test/resources/spdx/validation-errors/spdx-2.3-malformed-uri.json
@@ -1,0 +1,60 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "spdxVersion": "SPDX-2.3",
+  "creationInfo": {
+    "created": "2023-01-01T00:00:00Z",
+    "creators": ["Tool: Test-1.0"],
+    "licenseListVersion": "3.21"
+  },
+  "name": "test-malformed-uri",
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://test.example.com/malformed-uri",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Root",
+      "name": "root-package",
+      "versionInfo": "1.0",
+      "downloadLocation": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/org/root@1.0",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-Valid",
+      "name": "valid-package",
+      "versionInfo": "2.0",
+      "downloadLocation": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/org/valid@2.0",
+          "referenceType": "purl"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Root"
+    },
+    {
+      "spdxElementId": "SPDXRef-Root",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-Valid"
+    }
+  ]
+}

--- a/src/test/resources/spdx/validation-errors/spdx-2.3-missing-purl.json
+++ b/src/test/resources/spdx/validation-errors/spdx-2.3-missing-purl.json
@@ -1,0 +1,60 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "spdxVersion": "SPDX-2.3",
+  "creationInfo": {
+    "created": "2023-01-01T00:00:00Z",
+    "creators": ["Tool: Test-1.0"],
+    "licenseListVersion": "3.21"
+  },
+  "name": "test-missing-purl",
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://test.example.com/missing-purl",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Root",
+      "name": "root-package",
+      "versionInfo": "1.0",
+      "downloadLocation": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/org/root@1.0",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-NoPurl",
+      "name": "package-without-purl",
+      "versionInfo": "2.0",
+      "downloadLocation": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "OTHER",
+          "referenceLocator": "https://example.com/repo",
+          "referenceType": "http://cyclonedx.org/referenctype/other-package-manager"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Root"
+    },
+    {
+      "spdxElementId": "SPDXRef-Root",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-NoPurl"
+    }
+  ]
+}

--- a/src/test/resources/spdx/validation-errors/spdx-2.3-multiple-errors.json
+++ b/src/test/resources/spdx/validation-errors/spdx-2.3-multiple-errors.json
@@ -1,0 +1,76 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "spdxVersion": "SPDX-2.3",
+  "creationInfo": {
+    "created": "2023-01-01T00:00:00Z",
+    "creators": ["Tool: Test-1.0"],
+    "licenseListVersion": "3.21"
+  },
+  "name": "test-multiple-errors",
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://test.example.com/multiple-errors",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-Root",
+      "name": "root-package",
+      "versionInfo": "1.0",
+      "downloadLocation": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/org/root@1.0",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-NoPurl1",
+      "name": "package-no-purl-1",
+      "versionInfo": "1.0",
+      "downloadLocation": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": []
+    },
+    {
+      "SPDXID": "SPDXRef-EmptyPurl",
+      "name": "package-empty-purl",
+      "versionInfo": "2.0",
+      "downloadLocation": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "filesAnalyzed": false,
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "   ",
+          "referenceType": "purl"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Root"
+    },
+    {
+      "spdxElementId": "SPDXRef-Root",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-NoPurl1"
+    },
+    {
+      "spdxElementId": "SPDXRef-Root",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-EmptyPurl"
+    }
+  ]
+}


### PR DESCRIPTION
### **User description**
Fix #566


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Limit SPDX validation to minimum required data, removing full document verification

- Skip packages without PURL instead of treating as validation errors

- Add caching mechanism to prevent duplicate package processing

- Collect and aggregate validation errors for non-PURL issues only

- Add comprehensive test cases for validation error scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SPDX Document"] -->|Parse & Validate| B["Check Document URIs"]
  B -->|Valid| C["Build Relationships"]
  C -->|Process Packages| D["Check for PURL"]
  D -->|Has PURL| E["Cache & Add to Graph"]
  D -->|No PURL| F["Skip Package"]
  C -->|Non-PURL Errors| G["Aggregate Errors"]
  G -->|Errors Found| H["Throw SpdxValidationException"]
  G -->|No Errors| I["Return Relationships"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>SpdxWrapper.java</strong><dd><code>Refactor validation logic and add error aggregation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guacsec/trustify-dependency-analytics/pull/567/files#diff-c47e03d6e9508d2bd9b1ab498ed206146a8ac6abdfc405b87a2d70b521d7340f">+94/-25</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>AnalysisTest.java</strong><dd><code>Update SPDX validation error message expectations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guacsec/trustify-dependency-analytics/pull/567/files#diff-9c2ac9eb9333ebd1db20eed461ec595c0848cc9db4a0bf95dea8c95ccf4057ae">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SpdxWrapperTest.java</strong><dd><code>Add comprehensive SPDX validation error test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guacsec/trustify-dependency-analytics/pull/567/files#diff-4db65f97fa4bb47cd29ff7b3dba03be6379d31835b32abefe731603795b8e094">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spdx-2.3-missing-purl.json</strong><dd><code>Test fixture for packages without PURL references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guacsec/trustify-dependency-analytics/pull/567/files#diff-7216e9766b6e7fcfe93598b95f6d1b6c386ae131e89fd4b1a87c35904e1d4782">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spdx-2.3-empty-purl-locator.json</strong><dd><code>Test fixture for packages with empty PURL locators</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guacsec/trustify-dependency-analytics/pull/567/files#diff-071c8773f2b083d0ae6f91ddc240b38ffd86457100fd0b63860a0759bc8ca0d7">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spdx-2.3-invalid-relationship.json</strong><dd><code>Test fixture for invalid relationship references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guacsec/trustify-dependency-analytics/pull/567/files#diff-d6df33fca064991973f46b935f52f31ba39509a15c99788032420c8fdb8d8b5c">+43/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spdx-2.3-malformed-uri.json</strong><dd><code>Test fixture for malformed element URIs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guacsec/trustify-dependency-analytics/pull/567/files#diff-4b1fd0c121c6231220302cf04e9cb0fcb5c16f0ba2bb93d72ad0284a0bf4fd40">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spdx-2.3-multiple-errors.json</strong><dd><code>Test fixture for multiple validation errors</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guacsec/trustify-dependency-analytics/pull/567/files#diff-b041db95517394ef073b812f827ea4b8a9739cb3bb0697c4d6af31684df146d2">+76/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>spdx-2.3-duplicate-packages.json</strong><dd><code>Test fixture for duplicate package references</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/guacsec/trustify-dependency-analytics/pull/567/files#diff-cc7cb20980451e2e52ddb4783045ed168e40c7bad375a32044b57a1769af834a">+70/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

