### PR TITLE
feat: add manually imported data into report

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandler.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandler.java
@@ -56,6 +56,7 @@ import jakarta.inject.Inject;
 public class TrustifyResponseHandler extends ProviderResponseHandler {
 
   private static final Logger LOGGER = Logger.getLogger(TrustifyResponseHandler.class);
+  private static final String DEFAULT_SOURCE = "manual";
 
   private static final Map<ScoreType, Integer> SCORE_TYPE_ORDER =
       Map.of(
@@ -222,9 +223,10 @@ public class TrustifyResponseHandler extends ProviderResponseHandler {
 
   private String getSource(JsonNode node) {
     var labels = node.get("labels");
-    if (labels == null) {
-      return null;
+    var importer = JsonUtils.getTextValue(labels, "importer");
+    if (importer == null || importer.isBlank()) {
+      return DEFAULT_SOURCE;
     }
-    return JsonUtils.getTextValue(labels, "importer");
+    return importer;
   }
 }

--- a/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandlerTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandlerTest.java
@@ -739,6 +739,59 @@ public class TrustifyResponseHandlerTest {
   }
 
   @Test
+  void testResponseToIssuesWithDefaultSource() throws IOException {
+    String jsonResponse =
+        """
+    {
+      "pkg:maven/org.postgresql/postgresql@42.5.0": [
+        {
+          "identifier": "CVE-2024-1597",
+          "description": "This is a description used as title",
+          "status": {
+            "affected": [
+            {
+              "labels": {
+                "file": "2024/rhsa-2024_1662.json",
+                "source": "https://security.access.redhat.com/data/csaf/v2/advisories/",
+                "type": "csaf"
+              },
+              "scores": [
+                {
+                  "type": "3.1",
+                  "value": 9.8,
+                  "severity": "critical"
+                }
+              ],
+              "ranges": [
+                {
+                  "events": [
+                    {
+                      "fixed": "42.5.5"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]}
+        }
+      ]
+    }
+    """;
+
+    byte[] responseBytes = jsonResponse.getBytes();
+    ProviderResponse result =
+        handler.responseToIssues(buildExchange(responseBytes, dependencyTree));
+
+    PackageItem packageItem = result.pkgItems().get("pkg:maven/org.postgresql/postgresql@42.5.0");
+    assertNotNull(packageItem);
+    List<Issue> issues = packageItem.issues();
+    assertEquals(1, issues.size());
+
+    Issue issue = issues.get(0);
+    assertEquals("manual", issue.getSource());
+  }
+
+  @Test
   void testResponseToIssuesWithMultipleFixedVersions() throws IOException {
     String jsonResponse =
         """


### PR DESCRIPTION
### **User description**
Fix #571


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add default "manual" source for manually imported data

- Handle missing importer labels gracefully with fallback

- Add test coverage for default source assignment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Missing Importer Label"] -- "getSource method" --> B["Return DEFAULT_SOURCE"]
  C["Importer Label Present"] -- "getSource method" --> D["Return Importer Value"]
  B --> E["Issue with manual source"]
  D --> F["Issue with importer source"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TrustifyResponseHandler.java</strong><dd><code>Add default source handling for manual imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandler.java

<ul><li>Add <code>DEFAULT_SOURCE</code> constant set to "manual"<br> <li> Modify <code>getSource()</code> method to return default source when labels are <br>null<br> <li> Add null check for importer value with fallback to default source</ul>


</details>


  </td>
  <td><a href="https://github.com/guacsec/trustify-dependency-analytics/pull/572/files#diff-c452268cf00b6ecf5c032b2b0614867a43a719de8028463a4b562e4327c243d6">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TrustifyResponseHandlerTest.java</strong><dd><code>Test default source for missing importer labels</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandlerTest.java

<ul><li>Add new test <code>testResponseToIssuesWithDefaultSource()</code> to verify default <br>source assignment<br> <li> Test validates that issues without importer label receive "manual" as <br>source<br> <li> Test covers the scenario with missing importer in labels object</ul>


</details>


  </td>
  <td><a href="https://github.com/guacsec/trustify-dependency-analytics/pull/572/files#diff-e73cdc8442d70727671ca620e9253a654c72ae22cf110323e1009ad96407cb55">+54/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

