### PR TITLE
fix: validate license responses

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/integration/licenses/LicensesIntegration.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/licenses/LicensesIntegration.java
@@ -33,6 +33,9 @@ import org.apache.camel.builder.endpoint.EndpointRouteBuilder;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+
 import io.github.guacsec.trustifyda.api.PackageRef;
 import io.github.guacsec.trustifyda.api.v5.LicensesRequest;
 import io.github.guacsec.trustifyda.api.v5.PackageLicenseResult;
@@ -40,6 +43,7 @@ import io.github.guacsec.trustifyda.api.v5.ProviderStatus;
 import io.github.guacsec.trustifyda.integration.Constants;
 import io.github.guacsec.trustifyda.integration.cache.CacheService;
 import io.github.guacsec.trustifyda.model.licenses.LicenseSplitResult;
+import io.github.guacsec.trustifyda.monitoring.MonitoringProcessor;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -52,6 +56,10 @@ import jakarta.ws.rs.core.Response;
 public class LicensesIntegration extends EndpointRouteBuilder {
 
   private static final String DEPS_DEV_SOURCE = "deps.dev";
+
+  private static final String LICENSES_POST_BODY_HINT =
+      "Expected JSON {\"purls\":[\"pkg:...\"]} with package URL strings.";
+
   private static final Logger LOGGER = Logger.getLogger(LicensesIntegration.class);
 
   @ConfigProperty(name = "api.licenses.depsdev.host", defaultValue = "https://api.deps.dev")
@@ -64,6 +72,7 @@ public class LicensesIntegration extends EndpointRouteBuilder {
   @Inject DepsDevResponseHandler responseHandler;
   @Inject SpdxLicenseService spdxLicenseService;
   @Inject CacheService cacheService;
+  @Inject MonitoringProcessor monitoringProcessor;
 
   @Override
   public void configure() {
@@ -81,6 +90,16 @@ public class LicensesIntegration extends EndpointRouteBuilder {
       .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_HEADER))
       .handled(true)
       .setBody().simple("${exception.message}");
+
+    onException(JsonParseException.class, JsonMappingException.class)
+      .routeId("onLicensesInvalidJson")
+      .useOriginalMessage()
+      .process(monitoringProcessor::processClientException)
+      .setHeader(Exchange.HTTP_RESPONSE_CODE, constant(Response.Status.BAD_REQUEST.getStatusCode()))
+      .setHeader(Exchange.CONTENT_TYPE, constant(MediaType.TEXT_PLAIN))
+      .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_HEADER))
+      .handled(true)
+      .process(this::setLicensesRequestErrorBody);
 
     from(direct("getLicense"))
       .routeId("getLicense")
@@ -216,6 +235,13 @@ public class LicensesIntegration extends EndpointRouteBuilder {
     Map<String, PackageLicenseResult> merged = new HashMap<>(result.packages());
     cacheHits.forEach((ref, r) -> merged.put(ref.ref(), r));
     exchange.getIn().setBody(new LicenseSplitResult(result.status(), merged));
+  }
+
+  private void setLicensesRequestErrorBody(Exchange exchange) {
+    Throwable ex = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Throwable.class);
+    String prefix =
+        ex instanceof JsonParseException ? "Malformed JSON. " : "Invalid request body. ";
+    exchange.getMessage().setBody(prefix + LICENSES_POST_BODY_HINT);
   }
 
   private void removeHeaders(Exchange exchange) {

--- a/src/main/java/io/github/guacsec/trustifyda/integration/licenses/LicensesIntegration.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/licenses/LicensesIntegration.java
@@ -60,6 +60,12 @@ public class LicensesIntegration extends EndpointRouteBuilder {
   private static final String LICENSES_POST_BODY_HINT =
       "Expected JSON {\"purls\":[\"pkg:...\"]} with package URL strings.";
 
+  private static final String LICENSES_POST_MALFORMED_JSON_MESSAGE =
+      "Malformed JSON. " + LICENSES_POST_BODY_HINT;
+
+  public static final String LICENSES_POST_INVALID_BODY_MESSAGE =
+      "Invalid request body. " + LICENSES_POST_BODY_HINT;
+
   private static final Logger LOGGER = Logger.getLogger(LicensesIntegration.class);
 
   @ConfigProperty(name = "api.licenses.depsdev.host", defaultValue = "https://api.deps.dev")
@@ -239,9 +245,21 @@ public class LicensesIntegration extends EndpointRouteBuilder {
 
   private void setLicensesRequestErrorBody(Exchange exchange) {
     Throwable ex = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Throwable.class);
-    String prefix =
-        ex instanceof JsonParseException ? "Malformed JSON. " : "Invalid request body. ";
-    exchange.getMessage().setBody(prefix + LICENSES_POST_BODY_HINT);
+    String body =
+        containsJsonParseException(ex)
+            ? LICENSES_POST_MALFORMED_JSON_MESSAGE
+            : LICENSES_POST_INVALID_BODY_MESSAGE;
+    exchange.getMessage().setBody(body);
+    exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, MediaType.TEXT_PLAIN);
+  }
+
+  private static boolean containsJsonParseException(Throwable ex) {
+    for (Throwable t = ex; t != null; t = t.getCause()) {
+      if (t instanceof JsonParseException) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private void removeHeaders(Exchange exchange) {
@@ -256,7 +274,7 @@ public class LicensesIntegration extends EndpointRouteBuilder {
   /** Clears HTTP headers from the REST consumer so the HTTP producer uses only the full URL. */
   private void processRequest(Exchange exchange) {
     removeHeaders(exchange);
-    exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, constant(MediaType.APPLICATION_JSON));
+    exchange.getMessage().setHeader(Exchange.CONTENT_TYPE, MediaType.APPLICATION_JSON);
     exchange.getMessage().setHeader(Exchange.HTTP_METHOD, HttpMethod.POST);
   }
 }

--- a/src/test/java/io/github/guacsec/trustifyda/integration/LicensesEndpointTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/LicensesEndpointTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.guacsec.trustifyda.integration;
+
+import static io.restassured.RestAssured.given;
+import static org.apache.camel.Exchange.CONTENT_TYPE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.github.guacsec.trustifyda.api.v5.LicenseProviderResult;
+import io.github.guacsec.trustifyda.extensions.OidcWiremockExtension;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@QuarkusTest
+@QuarkusTestResource(OidcWiremockExtension.class)
+public class LicensesEndpointTest extends AbstractAnalysisTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /** Matches {@link io.github.guacsec.trustifyda.integration.licenses.LicensesIntegration}. */
+  private static final String INVALID_BODY_MESSAGE =
+      "Invalid request body. Expected JSON {\"purls\":[\"pkg:...\"]} with package URL strings.";
+
+  private static final String PURL_QUARKUS_H2 = "pkg:maven/io.quarkus/quarkus-jdbc-h2@2.13.5.Final";
+  private static final String PURL_CDI_API =
+      "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2";
+
+  @Test
+  public void postLicenses_multiplePurls_returnsLicensesAndCallsDepsDev() throws Exception {
+    stubLicensesRequests();
+
+    String requestJson =
+        MAPPER.writeValueAsString(Map.of("purls", List.of(PURL_QUARKUS_H2, PURL_CDI_API)));
+
+    String json =
+        given()
+            .header(CONTENT_TYPE, MediaType.APPLICATION_JSON)
+            .header("Accept", MediaType.APPLICATION_JSON)
+            .body(requestJson)
+            .when()
+            .post("/api/v5/licenses")
+            .then()
+            .statusCode(Response.Status.OK.getStatusCode())
+            .contentType(MediaType.APPLICATION_JSON)
+            .extract()
+            .body()
+            .asString();
+
+    verifyLicensesRequest(1);
+
+    List<LicenseProviderResult> results =
+        MAPPER.readValue(json, new TypeReference<List<LicenseProviderResult>>() {});
+    assertEquals(1, results.size());
+    LicenseProviderResult depsDev = results.get(0);
+    assertNotNull(depsDev.getStatus());
+    assertTrue(depsDev.getStatus().getOk());
+    assertEquals("deps.dev", depsDev.getStatus().getName());
+    var packages = depsDev.getPackages();
+    assertTrue(
+        packages.containsKey(PURL_QUARKUS_H2), "Response should include first requested purl");
+    assertTrue(packages.containsKey(PURL_CDI_API), "Response should include second requested purl");
+    assertNotNull(packages.get(PURL_QUARKUS_H2).getConcluded());
+    assertNotNull(packages.get(PURL_CDI_API).getConcluded());
+    assertFalse(packages.get(PURL_QUARKUS_H2).getEvidence().isEmpty());
+  }
+
+  @Test
+  public void postLicenses_emptyPurls_returnsOkWithoutDepsDevCall() throws Exception {
+    String json =
+        given()
+            .header(CONTENT_TYPE, MediaType.APPLICATION_JSON)
+            .header("Accept", MediaType.APPLICATION_JSON)
+            .body("{\"purls\":[]}")
+            .when()
+            .post("/api/v5/licenses")
+            .then()
+            .statusCode(Response.Status.OK.getStatusCode())
+            .contentType(MediaType.APPLICATION_JSON)
+            .extract()
+            .body()
+            .asString();
+
+    verifyLicensesRequest(0);
+
+    List<LicenseProviderResult> results =
+        MAPPER.readValue(json, new TypeReference<List<LicenseProviderResult>>() {});
+    assertEquals(1, results.size());
+    LicenseProviderResult depsDev = results.get(0);
+    assertNotNull(depsDev.getStatus());
+    assertTrue(depsDev.getStatus().getOk());
+    assertEquals("deps.dev", depsDev.getStatus().getName());
+    assertTrue(depsDev.getPackages().isEmpty());
+  }
+
+  @Test
+  public void postLicenses_invalidPurl_returnsBadRequestAndPlainHint() {
+    String body =
+        given()
+            .header(CONTENT_TYPE, MediaType.APPLICATION_JSON)
+            .body("{\"purls\":[\"\"]}")
+            .when()
+            .post("/api/v5/licenses")
+            .then()
+            .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+            .contentType(MediaType.TEXT_PLAIN)
+            .extract()
+            .body()
+            .asString();
+
+    assertEquals(INVALID_BODY_MESSAGE, body);
+    verifyLicensesRequest(0);
+  }
+}

--- a/src/test/java/io/github/guacsec/trustifyda/integration/LicensesEndpointTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/LicensesEndpointTest.java
@@ -17,6 +17,7 @@
 
 package io.github.guacsec.trustifyda.integration;
 
+import static io.github.guacsec.trustifyda.integration.licenses.LicensesIntegration.LICENSES_POST_INVALID_BODY_MESSAGE;
 import static io.restassured.RestAssured.given;
 import static org.apache.camel.Exchange.CONTENT_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -45,10 +48,6 @@ import jakarta.ws.rs.core.Response;
 public class LicensesEndpointTest extends AbstractAnalysisTest {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
-
-  /** Matches {@link io.github.guacsec.trustifyda.integration.licenses.LicensesIntegration}. */
-  private static final String INVALID_BODY_MESSAGE =
-      "Invalid request body. Expected JSON {\"purls\":[\"pkg:...\"]} with package URL strings.";
 
   private static final String PURL_QUARKUS_H2 = "pkg:maven/io.quarkus/quarkus-jdbc-h2@2.13.5.Final";
   private static final String PURL_CDI_API =
@@ -121,6 +120,74 @@ public class LicensesEndpointTest extends AbstractAnalysisTest {
     assertTrue(depsDev.getPackages().isEmpty());
   }
 
+  /** Missing {@code purls} is treated like an empty request (same as {@code null}). */
+  @Test
+  public void postLicenses_missingPurls_returnsOkWithoutDepsDevCall() throws Exception {
+    String json =
+        given()
+            .header(CONTENT_TYPE, MediaType.APPLICATION_JSON)
+            .header("Accept", MediaType.APPLICATION_JSON)
+            .body("{}")
+            .when()
+            .post("/api/v5/licenses")
+            .then()
+            .statusCode(Response.Status.OK.getStatusCode())
+            .contentType(MediaType.APPLICATION_JSON)
+            .extract()
+            .body()
+            .asString();
+
+    verifyLicensesRequest(0);
+
+    List<LicenseProviderResult> results =
+        MAPPER.readValue(json, new TypeReference<List<LicenseProviderResult>>() {});
+    assertEquals(1, results.size());
+    assertTrue(results.get(0).getPackages().isEmpty());
+  }
+
+  /** Malformed JSON is rejected by quarkus-rest-jackson before reaching the Camel route. */
+  @Test
+  public void postLicenses_malformedJson_returnsBadRequest() {
+    given()
+        .header(CONTENT_TYPE, MediaType.APPLICATION_JSON)
+        .body("{\"purls\":[}")
+        .when()
+        .post("/api/v5/licenses")
+        .then()
+        .statusCode(Response.Status.BAD_REQUEST.getStatusCode());
+
+    verifyLicensesRequest(0);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "{\"purls\":\"not-array\"}",
+        "{\"purls\":[123]}",
+        "{\"purls\":[true]}",
+      })
+  public void postLicenses_invalidJsonShape_returnsBadRequestAndPlainHint(String requestJson) {
+    String body =
+        given()
+            .header(CONTENT_TYPE, MediaType.APPLICATION_JSON)
+            .body(requestJson)
+            .when()
+            .post("/api/v5/licenses")
+            .then()
+            .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+            .contentType(MediaType.TEXT_PLAIN)
+            .extract()
+            .body()
+            .asString();
+
+    assertEquals(LICENSES_POST_INVALID_BODY_MESSAGE, body);
+    verifyLicensesRequest(0);
+  }
+
+  /**
+   * Empty purl string fails PackageRef deserialization, triggering the JsonMappingException
+   * handler.
+   */
   @Test
   public void postLicenses_invalidPurl_returnsBadRequestAndPlainHint() {
     String body =
@@ -136,7 +203,7 @@ public class LicensesEndpointTest extends AbstractAnalysisTest {
             .body()
             .asString();
 
-    assertEquals(INVALID_BODY_MESSAGE, body);
+    assertEquals(LICENSES_POST_INVALID_BODY_MESSAGE, body);
     verifyLicensesRequest(0);
   }
 }


### PR DESCRIPTION
Fix [TC-4327](https://redhat.atlassian.net/browse/TC-4327)

Adding validation for invalid requests

[TC-4327]: https://redhat.atlassian.net/browse/TC-4327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Validate and handle invalid JSON or body content in the licenses endpoint requests, and cover the behavior with endpoint tests.

Bug Fixes:
- Return HTTP 400 with a clear plain-text explanation when the licenses endpoint receives malformed JSON or an invalid request body.
- Prevent downstream deps.dev calls when the licenses endpoint receives invalid or empty purl inputs.

Tests:
- Add Quarkus integration tests for the /api/v5/licenses endpoint covering valid, empty, and invalid purl request bodies.