### PR TITLE
feat(sbom): extract component hashes from CycloneDX and SPDX SBOMs

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/integration/sbom/cyclonedx/CycloneDxParser.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/sbom/cyclonedx/CycloneDxParser.java
@@ -19,6 +19,7 @@ package io.github.guacsec.trustifyda.integration.sbom.cyclonedx;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -68,10 +69,12 @@ public class CycloneDxParser extends SbomParser {
               .collect(Collectors.toMap(Component::getBomRef, c -> new PackageRef(c.getPurl()))));
       for (Component c : bom.getComponents()) {
         if (c.getPurl() != null && c.getHashes() != null) {
-          Map<String, String> hashes =
-              c.getHashes().stream().collect(Collectors.toMap(Hash::getAlgorithm, Hash::getValue));
+          Map<String, String> hashes = new HashMap<>();
+          for (Hash h : c.getHashes()) {
+            hashes.put(h.getAlgorithm(), h.getValue());
+          }
           if (!hashes.isEmpty()) {
-            componentHashes.put(c.getPurl(), hashes);
+            componentHashes.put(c.getPurl(), Collections.unmodifiableMap(hashes));
           }
         }
       }

--- a/src/main/java/io/github/guacsec/trustifyda/integration/sbom/cyclonedx/CycloneDxParser.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/sbom/cyclonedx/CycloneDxParser.java
@@ -32,6 +32,7 @@ import org.cyclonedx.Version;
 import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
+import org.cyclonedx.model.Hash;
 import org.cyclonedx.parsers.JsonParser;
 import org.jboss.logging.Logger;
 
@@ -59,11 +60,21 @@ public class CycloneDxParser extends SbomParser {
     var treeBuilder = DependencyTree.builder();
     var bom = parseBom(input);
     Map<String, PackageRef> componentPurls = new HashMap<>();
+    Map<String, Map<String, String>> componentHashes = new HashMap<>();
     if (bom.getComponents() != null) {
       componentPurls.putAll(
           bom.getComponents().stream()
               .filter(c -> c.getBomRef() != null && c.getPurl() != null)
               .collect(Collectors.toMap(Component::getBomRef, c -> new PackageRef(c.getPurl()))));
+      for (Component c : bom.getComponents()) {
+        if (c.getPurl() != null && c.getHashes() != null) {
+          Map<String, String> hashes =
+              c.getHashes().stream().collect(Collectors.toMap(Hash::getAlgorithm, Hash::getValue));
+          if (!hashes.isEmpty()) {
+            componentHashes.put(c.getPurl(), hashes);
+          }
+        }
+      }
     }
 
     Optional<Component> rootComponent = Optional.empty();
@@ -90,6 +101,7 @@ public class CycloneDxParser extends SbomParser {
         .root(rootRef)
         .dependencies(buildDependencies(bom, componentPurls, rootRef))
         .licenseExpressions(buildLicenses(bom, rootRef))
+        .componentHashes(componentHashes)
         .build();
   }
 

--- a/src/main/java/io/github/guacsec/trustifyda/integration/sbom/spdx/SpdxParser.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/sbom/spdx/SpdxParser.java
@@ -35,7 +35,7 @@ public class SpdxParser extends SbomParser {
   public DependencyTree buildTree(InputStream input) {
     var wrapper = new SpdxWrapper(input);
     var deps = buildDeps(wrapper);
-    return new DependencyTree(deps, null, null);
+    return new DependencyTree(deps, null, null, wrapper.getComponentHashes());
   }
 
   private Map<PackageRef, DirectDependency> buildDeps(SpdxWrapper wrapper) {

--- a/src/main/java/io/github/guacsec/trustifyda/integration/sbom/spdx/SpdxWrapper.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/sbom/spdx/SpdxWrapper.java
@@ -20,6 +20,7 @@ package io.github.guacsec.trustifyda.integration.sbom.spdx;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -262,7 +263,7 @@ public class SpdxWrapper {
       hashes.put(checksum.getAlgorithm().toString(), checksum.getValue());
     }
     if (!hashes.isEmpty()) {
-      componentHashes.put(pkgRef.ref(), hashes);
+      componentHashes.put(pkgRef.ref(), Collections.unmodifiableMap(hashes));
     }
   }
 

--- a/src/main/java/io/github/guacsec/trustifyda/integration/sbom/spdx/SpdxWrapper.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/sbom/spdx/SpdxWrapper.java
@@ -31,6 +31,7 @@ import org.spdx.core.InvalidSPDXAnalysisException;
 import org.spdx.core.TypedValue;
 import org.spdx.jacksonstore.MultiFormatStore;
 import org.spdx.library.SpdxModelFactory;
+import org.spdx.library.model.v2.Checksum;
 import org.spdx.library.model.v2.ExternalRef;
 import org.spdx.library.model.v2.SpdxConstantsCompatV2;
 import org.spdx.library.model.v2.SpdxDocument;
@@ -51,6 +52,7 @@ public class SpdxWrapper {
   private String docUri;
   private Map<PackageRef, Set<PackageRef>> relationships;
   private Set<PackageRef> startFrom = new HashSet<>();
+  private Map<String, Map<String, String>> componentHashes = new HashMap<>();
 
   static {
     SpdxModelFactory.init();
@@ -185,6 +187,7 @@ public class SpdxWrapper {
                   setStartFromPackages(pkg, validationErrors, uriToRef);
                 }
                 var pkgRef = toPackageRefCached(pkg, uriToRef);
+                extractChecksum(pkg, pkgRef);
                 for (var relationship : pkg.getRelationships()) {
                   var rType = relationship.getRelationshipType();
                   var related = relationship.getRelatedSpdxElement();
@@ -246,6 +249,21 @@ public class SpdxWrapper {
 
   public Map<PackageRef, Set<PackageRef>> getRelationships() {
     return this.relationships;
+  }
+
+  public Map<String, Map<String, String>> getComponentHashes() {
+    return this.componentHashes;
+  }
+
+  private void extractChecksum(SpdxPackage pkg, PackageRef pkgRef)
+      throws InvalidSPDXAnalysisException {
+    Map<String, String> hashes = new HashMap<>();
+    for (Checksum checksum : pkg.getChecksums()) {
+      hashes.put(checksum.getAlgorithm().toString(), checksum.getValue());
+    }
+    if (!hashes.isEmpty()) {
+      componentHashes.put(pkgRef.ref(), hashes);
+    }
   }
 
   private boolean isRoot(String rootUri, SpdxPackage spdxPackage)

--- a/src/main/java/io/github/guacsec/trustifyda/model/DependencyTree.java
+++ b/src/main/java/io/github/guacsec/trustifyda/model/DependencyTree.java
@@ -32,7 +32,8 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 public record DependencyTree(
     Map<PackageRef, DirectDependency> dependencies,
     Map<String, String> licenseExpressions,
-    PackageRef root) {
+    PackageRef root,
+    Map<String, Map<String, String>> componentHashes) {
 
   public static final PackageRef getDefaultRoot(String type) {
     return PackageRef.builder()
@@ -48,6 +49,11 @@ public record DependencyTree(
       dependencies = Collections.unmodifiableMap(dependencies);
     } else {
       dependencies = Collections.emptyMap();
+    }
+    if (componentHashes != null) {
+      componentHashes = Collections.unmodifiableMap(componentHashes);
+    } else {
+      componentHashes = Collections.emptyMap();
     }
   }
 
@@ -91,6 +97,7 @@ public record DependencyTree(
     public Map<PackageRef, DirectDependency> dependencies;
     public Map<String, String> licenseExpressions;
     public PackageRef root;
+    public Map<String, Map<String, String>> componentHashes;
 
     public Builder licenseExpressions(Map<String, String> licenseExpressions) {
       this.licenseExpressions = licenseExpressions;
@@ -107,8 +114,13 @@ public record DependencyTree(
       return this;
     }
 
+    public Builder componentHashes(Map<String, Map<String, String>> componentHashes) {
+      this.componentHashes = componentHashes;
+      return this;
+    }
+
     public DependencyTree build() {
-      return new DependencyTree(dependencies, licenseExpressions, root);
+      return new DependencyTree(dependencies, licenseExpressions, root, componentHashes);
     }
   }
 }

--- a/src/test/java/io/github/guacsec/trustifyda/integration/backend/sbom/cyclonedx/CycloneDxParserTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/backend/sbom/cyclonedx/CycloneDxParserTest.java
@@ -18,6 +18,7 @@
 package io.github.guacsec.trustifyda.integration.backend.sbom.cyclonedx;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -138,6 +139,55 @@ class CycloneDxParserTest {
         assertNotNull(tree);
         assertTrue(tree.dependencies().isEmpty());
       }
+    }
+  }
+
+  /** Verifies that all hashes are extracted from CycloneDX component entries. */
+  @Test
+  void testParseHashesFromComponents() throws IOException {
+    CycloneDxParser parser = new CycloneDxParser();
+    try (InputStream input =
+        getClass().getResourceAsStream(TEST_RESOURCES_PATH + "sbom-with-hashes.json")) {
+      assertNotNull(input, "Test resource not found");
+
+      DependencyTree tree = parser.buildTree(input);
+      Map<String, Map<String, String>> hashes = tree.componentHashes();
+
+      assertNotNull(hashes);
+      assertEquals(2, hashes.size());
+
+      Map<String, String> dep1Hashes = hashes.get("pkg:maven/com.example/dep1@1.0.0");
+      assertNotNull(dep1Hashes);
+      assertEquals(1, dep1Hashes.size());
+      assertEquals(
+          "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+          dep1Hashes.get("SHA-256"));
+
+      Map<String, String> dep2Hashes = hashes.get("pkg:maven/com.example/dep2@1.0.0");
+      assertNotNull(dep2Hashes);
+      assertEquals(2, dep2Hashes.size());
+      assertEquals("d41d8cd98f00b204e9800998ecf8427e", dep2Hashes.get("MD5"));
+      assertEquals(
+          "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+          dep2Hashes.get("SHA-256"));
+
+      assertFalse(hashes.containsKey("pkg:maven/com.example/dep3@1.0.0"));
+    }
+  }
+
+  /** Verifies that parsing a SBOM without hashes produces an empty hash map without errors. */
+  @Test
+  void testParseHashesFromComponentsWithoutHashes() throws IOException {
+    CycloneDxParser parser = new CycloneDxParser();
+    try (InputStream input =
+        getClass().getResourceAsStream(TEST_RESOURCES_PATH + "valid-1.6.json")) {
+      assertNotNull(input, "Test resource not found");
+
+      DependencyTree tree = parser.buildTree(input);
+      Map<String, Map<String, String>> hashes = tree.componentHashes();
+
+      assertNotNull(hashes);
+      assertTrue(hashes.isEmpty());
     }
   }
 

--- a/src/test/java/io/github/guacsec/trustifyda/integration/backend/sbom/spdx/SpdxParserTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/backend/sbom/spdx/SpdxParserTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.guacsec.trustifyda.integration.backend.sbom.spdx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.guacsec.trustifyda.integration.sbom.spdx.SpdxParser;
+import io.github.guacsec.trustifyda.model.DependencyTree;
+
+class SpdxParserTest {
+
+  private static final String TEST_RESOURCES_PATH = "/spdx/";
+
+  /** Verifies that all checksums are extracted from SPDX package entries. */
+  @Test
+  void testParseHashesFromPackages() throws IOException {
+    SpdxParser parser = new SpdxParser();
+    try (InputStream input =
+        getClass().getResourceAsStream(TEST_RESOURCES_PATH + "sbom-with-hashes.json")) {
+      assertNotNull(input, "Test resource not found");
+
+      DependencyTree tree = parser.buildTree(input);
+      Map<String, Map<String, String>> hashes = tree.componentHashes();
+
+      assertNotNull(hashes);
+      assertEquals(2, hashes.size());
+
+      Map<String, String> dep1Hashes = hashes.get("pkg:maven/com.example/dep1@1.0.0");
+      assertNotNull(dep1Hashes);
+      assertEquals(1, dep1Hashes.size());
+      assertEquals(
+          "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+          dep1Hashes.get("SHA256"));
+
+      Map<String, String> dep2Hashes = hashes.get("pkg:maven/com.example/dep2@1.0.0");
+      assertNotNull(dep2Hashes);
+      assertEquals(2, dep2Hashes.size());
+      assertEquals("d41d8cd98f00b204e9800998ecf8427e", dep2Hashes.get("MD5"));
+      assertEquals(
+          "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+          dep2Hashes.get("SHA256"));
+
+      assertFalse(hashes.containsKey("pkg:maven/com.example/dep3@1.0.0"));
+    }
+  }
+
+  /** Verifies that parsing a SBOM without checksums produces an empty hash map. */
+  @Test
+  void testParseHashesFromPackagesWithoutChecksums() throws IOException {
+    SpdxParser parser = new SpdxParser();
+    try (InputStream input =
+        getClass().getResourceAsStream(TEST_RESOURCES_PATH + "empty-sbom.json")) {
+      assertNotNull(input, "Test resource not found");
+
+      DependencyTree tree = parser.buildTree(input);
+      Map<String, Map<String, String>> hashes = tree.componentHashes();
+
+      assertNotNull(hashes);
+      assertTrue(hashes.isEmpty());
+    }
+  }
+}

--- a/src/test/resources/cyclonedx/sbom-with-hashes.json
+++ b/src/test/resources/cyclonedx/sbom-with-hashes.json
@@ -1,0 +1,70 @@
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.6",
+    "version": 1,
+    "metadata": {
+        "component": {
+            "bom-ref": "pkg:maven/com.example/app@1.0.0",
+            "type": "application",
+            "name": "app",
+            "version": "1.0.0",
+            "purl": "pkg:maven/com.example/app@1.0.0"
+        }
+    },
+    "components": [
+        {
+            "bom-ref": "pkg:maven/com.example/app@1.0.0",
+            "type": "application",
+            "name": "app",
+            "version": "1.0.0",
+            "purl": "pkg:maven/com.example/app@1.0.0"
+        },
+        {
+            "bom-ref": "pkg:maven/com.example/dep1@1.0.0",
+            "type": "library",
+            "name": "dep1",
+            "version": "1.0.0",
+            "purl": "pkg:maven/com.example/dep1@1.0.0",
+            "hashes": [
+                {
+                    "alg": "SHA-256",
+                    "content": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:maven/com.example/dep2@1.0.0",
+            "type": "library",
+            "name": "dep2",
+            "version": "1.0.0",
+            "purl": "pkg:maven/com.example/dep2@1.0.0",
+            "hashes": [
+                {
+                    "alg": "MD5",
+                    "content": "d41d8cd98f00b204e9800998ecf8427e"
+                },
+                {
+                    "alg": "SHA-256",
+                    "content": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3"
+                }
+            ]
+        },
+        {
+            "bom-ref": "pkg:maven/com.example/dep3@1.0.0",
+            "type": "library",
+            "name": "dep3",
+            "version": "1.0.0",
+            "purl": "pkg:maven/com.example/dep3@1.0.0"
+        }
+    ],
+    "dependencies": [
+        {
+            "ref": "pkg:maven/com.example/app@1.0.0",
+            "dependsOn": [
+                "pkg:maven/com.example/dep1@1.0.0",
+                "pkg:maven/com.example/dep2@1.0.0",
+                "pkg:maven/com.example/dep3@1.0.0"
+            ]
+        }
+    ]
+}

--- a/src/test/resources/spdx/sbom-with-hashes.json
+++ b/src/test/resources/spdx/sbom-with-hashes.json
@@ -1,0 +1,119 @@
+{
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "spdxVersion": "SPDX-2.3",
+  "creationInfo": {
+    "created": "2024-01-01T00:00:00Z",
+    "creators": ["Tool: test"]
+  },
+  "name": "test-app",
+  "dataLicense": "CC0-1.0",
+  "documentNamespace": "https://example.com/test-sbom-with-hashes",
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-app",
+      "name": "app",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/com.example/app@1.0.0",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-dep1",
+      "name": "dep1",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+        }
+      ],
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/com.example/dep1@1.0.0",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-dep2",
+      "name": "dep2",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "checksums": [
+        {
+          "algorithm": "MD5",
+          "checksumValue": "d41d8cd98f00b204e9800998ecf8427e"
+        },
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3"
+        }
+      ],
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/com.example/dep2@1.0.0",
+          "referenceType": "purl"
+        }
+      ]
+    },
+    {
+      "SPDXID": "SPDXRef-dep3",
+      "name": "dep3",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceLocator": "pkg:maven/com.example/dep3@1.0.0",
+          "referenceType": "purl"
+        }
+      ]
+    }
+  ],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-app"
+    },
+    {
+      "spdxElementId": "SPDXRef-app",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-dep1"
+    },
+    {
+      "spdxElementId": "SPDXRef-app",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-dep2"
+    },
+    {
+      "spdxElementId": "SPDXRef-app",
+      "relationshipType": "DEPENDS_ON",
+      "relatedSpdxElement": "SPDXRef-dep3"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `componentHashes` field to `DependencyTree` as `Map<String, Map<String, String>>` (purl → algorithm → hash value)
- Extract all available checksums from CycloneDX components and SPDX packages
- Add tests and SBOM fixtures for both formats

## Jira

[TC-4334](https://redhat.atlassian.net/browse/TC-4334)

## Test plan

- [x] CycloneDX: SHA-256 and MD5 hashes extracted from components
- [x] CycloneDX: components without hashes produce empty map
- [x] SPDX: SHA256 and MD5 checksums extracted from packages
- [x] SPDX: packages without checksums produce empty map
- [x] All 16 tests pass (`mvn test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4334]: https://redhat.atlassian.net/browse/TC-4334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add support for capturing per-component checksum hashes from CycloneDX and SPDX SBOMs in the dependency tree model.

New Features:
- Expose a componentHashes map on DependencyTree to store checksum hashes per component purl.
- Extract checksum hashes from CycloneDX component entries into the dependency tree.
- Extract checksum hashes from SPDX package entries into the dependency tree via the SpdxWrapper and SpdxParser.

Tests:
- Add CycloneDX parser tests and fixtures to verify hash extraction and behavior when no hashes are present.
- Add SPDX parser tests and fixtures to verify checksum extraction and behavior when no checksums are present.