### PR TITLE
fix(licenses): return 400 for empty body on POST /api/v5/licenses

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/integration/licenses/LicensesIntegration.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/licenses/LicensesIntegration.java
@@ -122,6 +122,17 @@ public class LicensesIntegration extends EndpointRouteBuilder {
 
     from(direct("getLicensesFromEndpoint"))
       .routeId("getLicensesFromEndpoint")
+      .choice()
+        .when(e -> {
+          Object b = e.getMessage().getBody();
+          return b == null || b.toString().isBlank();
+        })
+          .setHeader(Exchange.HTTP_RESPONSE_CODE, constant(Response.Status.BAD_REQUEST.getStatusCode()))
+          .setHeader(Exchange.CONTENT_TYPE, constant(MediaType.TEXT_PLAIN))
+          .setHeader(Constants.EXHORT_REQUEST_ID_HEADER, exchangeProperty(Constants.EXHORT_REQUEST_ID_HEADER))
+          .setBody(constant(LICENSES_POST_INVALID_BODY_MESSAGE))
+          .stop()
+      .end()
       .unmarshal().json(LicensesRequest.class)
       .transform(method(requestBuilder, "fromEndpoint"))
       .to(direct("getLicenses"))

--- a/src/main/java/io/github/guacsec/trustifyda/integration/licenses/LicensesIntegration.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/licenses/LicensesIntegration.java
@@ -124,8 +124,8 @@ public class LicensesIntegration extends EndpointRouteBuilder {
       .routeId("getLicensesFromEndpoint")
       .choice()
         .when(e -> {
-          Object b = e.getMessage().getBody();
-          return b == null || b.toString().isBlank();
+          byte[] b = e.getMessage().getBody(byte[].class);
+          return b == null || b.length == 0;
         })
           .setHeader(Exchange.HTTP_RESPONSE_CODE, constant(Response.Status.BAD_REQUEST.getStatusCode()))
           .setHeader(Exchange.CONTENT_TYPE, constant(MediaType.TEXT_PLAIN))

--- a/src/test/java/io/github/guacsec/trustifyda/integration/LicensesEndpointTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/LicensesEndpointTest.java
@@ -206,4 +206,43 @@ public class LicensesEndpointTest extends AbstractAnalysisTest {
     assertEquals(LICENSES_POST_INVALID_BODY_MESSAGE, body);
     verifyLicensesRequest(0);
   }
+
+  /** Verifies that an empty string body returns 400 instead of 500. */
+  @Test
+  public void postLicenses_emptyBody_returnsBadRequest() {
+    String body =
+        given()
+            .header(CONTENT_TYPE, MediaType.APPLICATION_JSON)
+            .body("")
+            .when()
+            .post("/api/v5/licenses")
+            .then()
+            .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+            .contentType(MediaType.TEXT_PLAIN)
+            .extract()
+            .body()
+            .asString();
+
+    assertEquals(LICENSES_POST_INVALID_BODY_MESSAGE, body);
+    verifyLicensesRequest(0);
+  }
+
+  /** Verifies that a request with no body at all returns 400 instead of 500. */
+  @Test
+  public void postLicenses_nullBody_returnsBadRequest() {
+    String body =
+        given()
+            .header(CONTENT_TYPE, MediaType.APPLICATION_JSON)
+            .when()
+            .post("/api/v5/licenses")
+            .then()
+            .statusCode(Response.Status.BAD_REQUEST.getStatusCode())
+            .contentType(MediaType.TEXT_PLAIN)
+            .extract()
+            .body()
+            .asString();
+
+    assertEquals(LICENSES_POST_INVALID_BODY_MESSAGE, body);
+    verifyLicensesRequest(0);
+  }
 }


### PR DESCRIPTION
## Summary

- Add null/empty body validation before `unmarshal()` in the `getLicensesFromEndpoint` Camel route
- When the request body is null or blank, return HTTP 400 with a descriptive `text/plain` error message instead of falling through to the dead letter channel (500)
- Add two new tests: `postLicenses_emptyBody_returnsBadRequest` and `postLicenses_nullBody_returnsBadRequest`

Implements [TC-4545](https://redhat.atlassian.net/browse/TC-4545)

## Test plan

- [ ] `POST /api/v5/licenses` with empty body (`""`) returns HTTP 400 with `text/plain` error message
- [ ] `POST /api/v5/licenses` with no body returns HTTP 400 with `text/plain` error message
- [ ] Existing license endpoint tests continue to pass
- [ ] `mvn spotless:check` passes (formatting verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4545]: https://redhat.atlassian.net/browse/TC-4545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Validate POST /api/v5/licenses request bodies and return a 400 Bad Request with a plain-text error message when the body is null or empty, and add tests to cover these scenarios.

Bug Fixes:
- Ensure POST /api/v5/licenses returns 400 Bad Request with a descriptive plain-text message instead of 500 when the request body is empty or missing.

Tests:
- Add integration tests verifying that empty and missing request bodies on POST /api/v5/licenses return 400 with the expected plain-text error message and no downstream license request processing.