### PR TITLE
fix: report vulnerabilities with null severity when CVSS scores are missing

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/ProviderResponseHandler.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/ProviderResponseHandler.java
@@ -409,14 +409,22 @@ public abstract class ProviderResponseHandler {
         && !transitiveItem.issues().isEmpty()) {
       transitiveIssues =
           transitiveItem.issues().stream()
-              .sorted(Comparator.comparing(Issue::getCvssScore).reversed())
+              .sorted(
+                  Comparator.comparing(
+                          Issue::getCvssScore, Comparator.nullsFirst(Comparator.naturalOrder()))
+                      .reversed())
               .collect(Collectors.toList());
     }
     var highestTransitive = transitiveIssues.stream().findFirst();
     if (highestTransitive.isPresent()) {
+      var currentScore =
+          directReport.getHighestVulnerability() == null
+              ? null
+              : directReport.getHighestVulnerability().getCvssScore();
+      var transitiveScore = highestTransitive.get().getCvssScore();
       if (directReport.getHighestVulnerability() == null
-          || directReport.getHighestVulnerability().getCvssScore()
-              < highestTransitive.get().getCvssScore()) {
+          || (transitiveScore != null
+              && (currentScore == null || currentScore < transitiveScore))) {
         directReport.setHighestVulnerability(highestTransitive.get());
       }
     }
@@ -442,7 +450,10 @@ public abstract class ProviderResponseHandler {
     if (packageItem != null && packageItem.issues() != null && !packageItem.issues().isEmpty()) {
       var issues =
           packageItem.issues().stream()
-              .sorted(Comparator.comparing(Issue::getCvssScore).reversed())
+              .sorted(
+                  Comparator.comparing(
+                          Issue::getCvssScore, Comparator.nullsFirst(Comparator.naturalOrder()))
+                      .reversed())
               .collect(Collectors.toList());
       directReport.issues(issues);
       directReport.setHighestVulnerability(issues.stream().findFirst().orElse(null));

--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandler.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandler.java
@@ -141,9 +141,7 @@ public class TrustifyResponseHandler extends ProviderResponseHandler {
                 }
                 var issue = new Issue().id(id).title(iTitle).source(source).cves(List.of(id));
                 setCvssData(issue, data);
-                if (issue.getCvssScore() != null) {
-                  issuesByCveSource.put(key, issue);
-                }
+                issuesByCveSource.put(key, issue);
               });
           issues.addAll(issuesByCveSource.values());
         });

--- a/src/main/java/io/github/guacsec/trustifyda/model/CvssScoreComparable.java
+++ b/src/main/java/io/github/guacsec/trustifyda/model/CvssScoreComparable.java
@@ -40,8 +40,10 @@ public interface CvssScoreComparable {
       if (d1.getHighestVulnerability() == null && d2.getHighestVulnerability() != null) {
         return -1;
       }
-      return Float.compare(
-          d1.getHighestVulnerability().getCvssScore(), d2.getHighestVulnerability().getCvssScore());
+      return Comparator.<Float>nullsFirst(Comparator.naturalOrder())
+          .compare(
+              d1.getHighestVulnerability().getCvssScore(),
+              d2.getHighestVulnerability().getCvssScore());
     }
   }
 
@@ -58,8 +60,10 @@ public interface CvssScoreComparable {
       if (d1.getHighestVulnerability() == null && d2.getHighestVulnerability() != null) {
         return -1;
       }
-      return Float.compare(
-          d1.getHighestVulnerability().getCvssScore(), d2.getHighestVulnerability().getCvssScore());
+      return Comparator.<Float>nullsFirst(Comparator.naturalOrder())
+          .compare(
+              d1.getHighestVulnerability().getCvssScore(),
+              d2.getHighestVulnerability().getCvssScore());
     }
   }
 }

--- a/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandlerTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandlerTest.java
@@ -21,6 +21,7 @@ import static io.github.guacsec.trustifyda.integration.providers.ProviderRespons
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.mock;
@@ -647,6 +648,9 @@ public class TrustifyResponseHandlerTest {
     assertTrue(issues.isEmpty());
   }
 
+  /**
+   * Verifies that a vulnerability with no scores is reported with null severity and null cvssScore.
+   */
   @Test
   void testResponseToIssuesWithNoScores() throws IOException {
     String jsonResponse =
@@ -661,6 +665,9 @@ public class TrustifyResponseHandlerTest {
             "affected": [
               {
                 "id": "advisory-1",
+                "labels": {
+                  "importer": "redhat-csaf"
+                },
                 "ranges": [
                   {
                     "events": [
@@ -683,11 +690,22 @@ public class TrustifyResponseHandlerTest {
     ProviderResponse result =
         handler.responseToIssues(buildExchange(responseBytes, dependencyTree));
 
+    // Given a vulnerability with no scores array
     assertNotNull(result);
     PackageItem packageItem = result.pkgItems().get("pkg:maven/org.postgresql/postgresql@42.5.0");
     assertNotNull(packageItem);
     List<Issue> issues = packageItem.issues();
-    assertTrue(issues.isEmpty());
+
+    // Then the vulnerability is still reported with null severity and null cvssScore
+    assertEquals(1, issues.size());
+    Issue issue = issues.get(0);
+    assertEquals("CVE-2024-1597", issue.getId());
+    assertNull(issue.getCvssScore(), "cvssScore should be null when no scores are available");
+    assertNull(issue.getSeverity(), "severity should be null when no scores are available");
+
+    // Then remediation data is still populated
+    assertNotNull(issue.getRemediation());
+    assertEquals(List.of("42.5.5"), issue.getRemediation().getFixedIn());
   }
 
   @Test
@@ -1182,6 +1200,10 @@ public class TrustifyResponseHandlerTest {
         "Package without warnings should not be marked as unscanned");
   }
 
+  /**
+   * Verifies that vulnerabilities with only invalid severity scores (e.g., "none") are reported
+   * with null severity, and that valid scores in mixed-score advisories are used correctly.
+   */
   @Test
   void testResponseToIssuesWithInvalidSeverity() throws IOException {
     String jsonResponse =
@@ -1267,20 +1289,85 @@ public class TrustifyResponseHandlerTest {
     assertNotNull(result.pkgItems());
     assertEquals(2, result.pkgItems().size());
 
-    // Package with empty details and warnings with data should be marked as unscanned
+    // Package with only invalid severity should be reported with null severity
     PackageItem packageItem1 = result.pkgItems().get("pkg:maven/org.postgresql/postgresql@42.5.0");
-    assertNotNull(packageItem1, "Package with no valid scores should be ignored");
+    assertNotNull(packageItem1);
     List<Issue> issues = packageItem1.issues();
-    assertTrue(issues.isEmpty(), "Package with no valid scores should have no issues");
+    assertEquals(1, issues.size(), "Vulnerability with invalid severity should still be reported");
+    assertNull(
+        issues.get(0).getCvssScore(),
+        "cvssScore should be null when all scores have invalid severity");
+    assertNull(
+        issues.get(0).getSeverity(),
+        "severity should be null when all scores have invalid severity");
 
-    // Package with invalid severity should be marked as unscanned
+    // Package with mixed valid/invalid scores should use the valid score
     PackageItem packageItem2 = result.pkgItems().get("pkg:maven/com.other/package@2.0.0");
     assertNotNull(packageItem2);
     issues = packageItem2.issues();
     assertFalse(issues.isEmpty(), "Package should have an issue");
-    assertEquals(issues.size(), 1, "Package should have one issue");
-    assertEquals(issues.get(0).getCvssScore(), 7.5f, "Issue should have the correct CVSS score");
+    assertEquals(1, issues.size(), "Package should have one issue");
+    assertEquals(7.5f, issues.get(0).getCvssScore(), "Issue should have the correct CVSS score");
     assertEquals(
-        issues.get(0).getSeverity(), Severity.HIGH, "Issue should have the correct severity");
+        Severity.HIGH, issues.get(0).getSeverity(), "Issue should have the correct severity");
+  }
+
+  /** Verifies that a vulnerability with an empty scores array is reported with null severity. */
+  @Test
+  void testResponseToIssuesWithEmptyScoresArray() throws IOException {
+    String jsonResponse =
+        """
+    {
+      "pkg:maven/org.postgresql/postgresql@42.5.0": {
+        "details": [
+          {
+            "identifier": "CVE-2025-24898",
+            "title": "Test CVE with empty scores",
+            "status": {
+              "affected": [
+                {
+                  "labels": {
+                    "importer": "osv-rustsec"
+                  },
+                  "scores": [],
+                  "ranges": [
+                    {
+                      "events": [
+                        {
+                          "fixed": "0.10.70"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "warnings": []
+      }
+    }
+    """;
+
+    byte[] responseBytes = jsonResponse.getBytes();
+    ProviderResponse result =
+        handler.responseToIssues(buildExchange(responseBytes, dependencyTree));
+
+    // Given a vulnerability with an empty scores array
+    assertNotNull(result);
+    PackageItem packageItem = result.pkgItems().get("pkg:maven/org.postgresql/postgresql@42.5.0");
+    assertNotNull(packageItem);
+    List<Issue> issues = packageItem.issues();
+
+    // Then the vulnerability is reported with null severity and null cvssScore
+    assertEquals(1, issues.size());
+    Issue issue = issues.get(0);
+    assertEquals("CVE-2025-24898", issue.getId());
+    assertNull(issue.getCvssScore(), "cvssScore should be null when scores array is empty");
+    assertNull(issue.getSeverity(), "severity should be null when scores array is empty");
+
+    // Then remediation data is still populated
+    assertNotNull(issue.getRemediation());
+    assertEquals(List.of("0.10.70"), issue.getRemediation().getFixedIn());
   }
 }


### PR DESCRIPTION
## Summary

- Remove the null-score guard in `TrustifyResponseHandler` that silently dropped vulnerabilities without CVSS scores (e.g., RUSTSEC advisories)
- Vulnerabilities are now reported with `null` severity and `null` cvssScore — the API spec already supports nullable fields
- Fix null-unsafe comparators in `ProviderResponseHandler` and `CvssScoreComparable` to handle `null` cvssScore with `Comparator.nullsFirst`, preventing NPEs during report building

Implements [TC-4548](https://redhat.atlassian.net/browse/TC-4548)

## Test plan

- [x] Vulnerability with no scores array → reported with null severity, null cvssScore, remediation still populated
- [x] Vulnerability with empty scores array → reported with null severity, null cvssScore
- [x] Vulnerability with only invalid severity (e.g., "none") → reported with null severity
- [x] Vulnerability with valid scores → reported with correct severity (unchanged behavior)
- [x] All existing tests pass (20/20 TrustifyResponseHandlerTest, 8/8 ProviderResponseHandlerTest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4548]: https://redhat.atlassian.net/browse/TC-4548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Report vulnerabilities even when CVSS scores are missing and make CVSS-based sorting null-safe.

New Features:
- Include vulnerabilities without CVSS scores in Trustify issue conversion, using null severity and cvssScore.

Bug Fixes:
- Prevent dropping advisories that lack CVSS scores or only have invalid severities when building issues.
- Handle null cvssScore values safely when sorting issues and dependency reports to avoid null pointer exceptions.

Tests:
- Expand TrustifyResponseHandler tests to cover vulnerabilities with no scores array, empty scores arrays, and only invalid severities.