### PR TITLE
fix(licenses): preserve original license name for non-standard deps.dev licenses

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/integration/licenses/DepsDevResponseHandler.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/licenses/DepsDevResponseHandler.java
@@ -84,8 +84,14 @@ public class DepsDevResponseHandler {
                 licensesNode.forEach(
                     licenseNode -> {
                       var spdx = licenseNode.get("spdx").asText();
+                      var licenseField = licenseNode.get("license");
+                      var license =
+                          licenseField != null && !licenseField.isNull()
+                              ? licenseField.asText()
+                              : null;
                       var info =
-                          spdxLicenseService.fromLicenseId(spdx, DEPS_DEV_SOURCE, depsDevHost);
+                          spdxLicenseService.fromLicenseId(
+                              spdx, DEPS_DEV_SOURCE, depsDevHost, license);
                       infos.add(info);
                     });
               }

--- a/src/main/java/io/github/guacsec/trustifyda/integration/licenses/SpdxLicenseService.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/licenses/SpdxLicenseService.java
@@ -163,6 +163,16 @@ public class SpdxLicenseService {
   }
 
   public LicenseInfo fromLicenseId(String expression, String sourceId, String sourceUrl) {
+    return fromLicenseId(expression, sourceId, sourceUrl, null);
+  }
+
+  /**
+   * Resolves a license expression to a {@link LicenseInfo} with identifiers, category, and
+   * human-readable name. When the expression is not a valid SPDX identifier (e.g., "non-standard"),
+   * {@code originalName} is used as the display name if provided.
+   */
+  public LicenseInfo fromLicenseId(
+      String expression, String sourceId, String sourceUrl, String originalName) {
     if (expression == null || expression.isBlank()) {
       throw new NotFoundException("License expression is required");
     }
@@ -177,10 +187,17 @@ public class SpdxLicenseService {
     } catch (InvalidSPDXAnalysisException e) {
       if (!trimmed.contains(" AND ") && !trimmed.contains(" OR ") && !trimmed.contains(" WITH ")) {
         LicenseCategory category = LicenseCategory.UNKNOWN;
+        String displayName =
+            (originalName != null && !originalName.isBlank()) ? originalName : trimmed;
         return new LicenseInfo()
-            .identifiers(List.of(toUnknownLicenseIdentifier(trimmed)))
+            .identifiers(
+                List.of(
+                    new LicenseIdentifier()
+                        .id(trimmed)
+                        .name(displayName)
+                        .category(LicenseCategory.UNKNOWN)))
             .category(category)
-            .name(trimmed)
+            .name(displayName)
             .source(sourceId == null ? SPDX_SOURCE : sourceId)
             .sourceUrl(sourceUrl == null ? SPDX_SOURCE_URL : sourceUrl)
             .expression(trimmed);

--- a/src/test/java/io/github/guacsec/trustifyda/integration/licenses/DepsDevResponseHandlerTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/licenses/DepsDevResponseHandlerTest.java
@@ -458,6 +458,70 @@ class DepsDevResponseHandlerTest {
     assertEquals(LicenseCategory.UNKNOWN, packageResult.getEvidence().get(0).getCategory());
   }
 
+  /** Verifies that non-standard SPDX values preserve the original license name from deps.dev. */
+  @Test
+  void testHandleResponse_nonStandardLicense_preservesOriginalName() {
+    String jsonResponse =
+        """
+        {
+          "responses": [
+            {
+              "request": {"purl": "pkg:maven/org.example/test@1.0"},
+              "result": {
+                "version": {
+                  "licenseDetails": [
+                    {"license": "GPL Version 2.0", "spdx": "non-standard"}
+                  ]
+                }
+              }
+            }
+          ]
+        }
+        """;
+
+    // When
+    Exchange exchange = buildExchange(jsonResponse);
+    handler.handleResponse(exchange);
+
+    // Then
+    LicenseSplitResult result = exchange.getMessage().getBody(LicenseSplitResult.class);
+    var packageResult = result.packages().get("pkg:maven/org.example/test@1.0");
+    assertNotNull(packageResult);
+    assertEquals(1, packageResult.getEvidence().size());
+    var licenseInfo = packageResult.getEvidence().get(0);
+    assertEquals(LicenseCategory.UNKNOWN, licenseInfo.getCategory());
+    assertEquals("GPL Version 2.0", licenseInfo.getName());
+    assertEquals("non-standard", licenseInfo.getIdentifiers().get(0).getId());
+    assertEquals("GPL Version 2.0", licenseInfo.getIdentifiers().get(0).getName());
+  }
+
+  /** Verifies that non-standard licenses preserve name in maven_response.json fixture. */
+  @Test
+  void testHandleResponse_mavenFixture_nonStandardLicenseHasOriginalName() throws IOException {
+    byte[] jsonResponseBytes;
+    try (var in =
+        getClass().getClassLoader().getResourceAsStream("__files/depsdev/maven_response.json")) {
+      jsonResponseBytes = in.readAllBytes();
+    }
+
+    Exchange exchange = buildExchange(new String(jsonResponseBytes));
+    handler.handleResponse(exchange);
+
+    LicenseSplitResult result = exchange.getMessage().getBody(LicenseSplitResult.class);
+
+    // jakarta.interceptor-api has "EPL 2.0" as license with "non-standard" spdx
+    var interceptorResult =
+        result.packages().get("pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5");
+    assertNotNull(interceptorResult);
+    var nonStandardEvidence =
+        interceptorResult.getEvidence().stream()
+            .filter(e -> "non-standard".equals(e.getExpression()))
+            .findFirst()
+            .orElseThrow(() -> new RuntimeException("non-standard license not found"));
+    assertEquals("EPL 2.0", nonStandardEvidence.getName());
+    assertEquals("EPL 2.0", nonStandardEvidence.getIdentifiers().get(0).getName());
+  }
+
   private Exchange buildExchange(String body) {
     Exchange exchange = mock(Exchange.class);
     Message inMessage = mock(Message.class);

--- a/src/test/java/io/github/guacsec/trustifyda/integration/licenses/SpdxLicenseServiceTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/licenses/SpdxLicenseServiceTest.java
@@ -416,6 +416,36 @@ public class SpdxLicenseServiceTest {
     assertThrows(NotFoundException.class, () -> service.fromLicenseId("   ", null, null));
   }
 
+  /** When SPDX value is "non-standard", the original license name is preserved in name fields. */
+  @Test
+  void testFromLicenseId_nonStandard_preservesOriginalName() {
+    LicenseInfo info = service.fromLicenseId("non-standard", null, null, "GPL Version 2.0");
+    assertEquals(LicenseCategory.UNKNOWN, info.getCategory());
+    assertEquals("GPL Version 2.0", info.getName());
+    assertEquals(1, info.getIdentifiers().size());
+    assertEquals("non-standard", info.getIdentifiers().get(0).getId());
+    assertEquals("GPL Version 2.0", info.getIdentifiers().get(0).getName());
+  }
+
+  /** When SPDX value is "non-standard" and no original name is provided, the SPDX value is used. */
+  @Test
+  void testFromLicenseId_nonStandard_fallsBackToSpdxValue() {
+    LicenseInfo info = service.fromLicenseId("non-standard", null, null, null);
+    assertEquals(LicenseCategory.UNKNOWN, info.getCategory());
+    assertEquals("non-standard", info.getName());
+    assertEquals("non-standard", info.getIdentifiers().get(0).getName());
+  }
+
+  /** When SPDX value is a valid identifier, the original name parameter is ignored. */
+  @Test
+  void testFromLicenseId_validSpdx_ignoresOriginalName() {
+    LicenseInfo info = service.fromLicenseId("MIT", null, null, "Some Other Name");
+    assertEquals(LicenseCategory.PERMISSIVE, info.getCategory());
+    assertEquals("MIT", info.getIdentifiers().get(0).getId());
+    // Name comes from SPDX library, not the original name parameter
+    assertNotNull(info.getName());
+  }
+
   /**
    * SPDX-listed license texts (popular ids) resolve to the expected id and policy category.
    * Fixtures are from <a

--- a/src/test/resources/__files/reports/batch_report.json
+++ b/src/test/resources/__files/reports/batch_report.json
@@ -525,12 +525,12 @@
                 "identifiers": [
                   {
                     "id": "non-standard",
-                    "name": "non-standard",
+                    "name": "EPL 2.0",
                     "category": "UNKNOWN"
                   }
                 ],
                 "expression": "non-standard",
-                "name": "non-standard",
+                "name": "EPL 2.0",
                 "category": "UNKNOWN",
                 "source": "deps.dev",
                 "sourceUrl": "https://api.deps.dev"
@@ -653,12 +653,12 @@
                 "identifiers": [
                   {
                     "id": "non-standard",
-                    "name": "non-standard",
+                    "name": "EPL 2.0",
                     "category": "UNKNOWN"
                   }
                 ],
                 "expression": "non-standard",
-                "name": "non-standard",
+                "name": "EPL 2.0",
                 "category": "UNKNOWN",
                 "source": "deps.dev",
                 "sourceUrl": "https://api.deps.dev"
@@ -976,12 +976,12 @@
                 "identifiers": [
                   {
                     "id": "non-standard",
-                    "name": "non-standard",
+                    "name": "EPL 2.0",
                     "category": "UNKNOWN"
                   }
                 ],
                 "expression": "non-standard",
-                "name": "non-standard",
+                "name": "EPL 2.0",
                 "category": "UNKNOWN",
                 "source": "deps.dev",
                 "sourceUrl": "https://api.deps.dev"
@@ -1104,12 +1104,12 @@
                 "identifiers": [
                   {
                     "id": "non-standard",
-                    "name": "non-standard",
+                    "name": "EPL 2.0",
                     "category": "UNKNOWN"
                   }
                 ],
                 "expression": "non-standard",
-                "name": "non-standard",
+                "name": "EPL 2.0",
                 "category": "UNKNOWN",
                 "source": "deps.dev",
                 "sourceUrl": "https://api.deps.dev"
@@ -1450,12 +1450,12 @@
                 "identifiers": [
                   {
                     "id": "non-standard",
-                    "name": "non-standard",
+                    "name": "EPL 2.0",
                     "category": "UNKNOWN"
                   }
                 ],
                 "expression": "non-standard",
-                "name": "non-standard",
+                "name": "EPL 2.0",
                 "category": "UNKNOWN",
                 "source": "deps.dev",
                 "sourceUrl": "https://api.deps.dev"
@@ -1578,12 +1578,12 @@
                 "identifiers": [
                   {
                     "id": "non-standard",
-                    "name": "non-standard",
+                    "name": "EPL 2.0",
                     "category": "UNKNOWN"
                   }
                 ],
                 "expression": "non-standard",
-                "name": "non-standard",
+                "name": "EPL 2.0",
                 "category": "UNKNOWN",
                 "source": "deps.dev",
                 "sourceUrl": "https://api.deps.dev"

--- a/src/test/resources/__files/reports/report.json
+++ b/src/test/resources/__files/reports/report.json
@@ -971,12 +971,12 @@
               "identifiers": [
                 {
                   "id": "non-standard",
-                  "name": "non-standard",
+                  "name": "EPL 2.0",
                   "category": "UNKNOWN"
                 }
               ],
               "expression": "non-standard",
-              "name": "non-standard",
+              "name": "EPL 2.0",
               "category": "UNKNOWN",
               "source": "deps.dev",
               "sourceUrl": "https://api.deps.dev"
@@ -1099,12 +1099,12 @@
               "identifiers": [
                 {
                   "id": "non-standard",
-                  "name": "non-standard",
+                  "name": "EPL 2.0",
                   "category": "UNKNOWN"
                 }
               ],
               "expression": "non-standard",
-              "name": "non-standard",
+              "name": "EPL 2.0",
               "category": "UNKNOWN",
               "source": "deps.dev",
               "sourceUrl": "https://api.deps.dev"


### PR DESCRIPTION
## Summary
- Extract the `license` field from deps.dev `licenseDetails` entries alongside `spdx`
- Pass the original license name to `SpdxLicenseService.fromLicenseId()` so non-standard licenses display their human-readable name (e.g., "GPL Version 2.0") instead of "non-standard"
- Handle edge case where `license` field is JSON null

## Test plan
- [x] New unit tests for `SpdxLicenseService.fromLicenseId()` with `originalName` parameter (3 tests)
- [x] New integration test for `DepsDevResponseHandler` with non-standard license name preservation (2 tests)
- [x] All 56 existing + new tests pass
- [x] Spotless formatting verified

Implements [TC-4586](https://redhat.atlassian.net/browse/TC-4586)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4586]: https://redhat.atlassian.net/browse/TC-4586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Preserve original, human-readable license names from deps.dev for non-standard SPDX values and expose them through the license resolution pipeline.

Bug Fixes:
- Ensure non-standard SPDX licenses from deps.dev use the original license name as the display name instead of the literal SPDX value when available.
- Handle null or missing deps.dev `license` fields safely when resolving license information.

Enhancements:
- Extend `SpdxLicenseService.fromLicenseId` to accept an optional original license name and use it for non-standard identifiers while keeping behavior for valid SPDX ids unchanged.

Tests:
- Add unit tests for `SpdxLicenseService.fromLicenseId` covering non-standard SPDX handling, fallback behavior, and ignoring the original name for valid SPDX ids.
- Add integration tests for `DepsDevResponseHandler` to verify preservation of original non-standard license names from deps.dev responses and fixtures.