### PR TITLE
fix(batch): preserve deterministic key ordering in batch analysis response

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/integration/backend/ExhortIntegration.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/backend/ExhortIntegration.java
@@ -30,6 +30,7 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -337,7 +338,9 @@ public class ExhortIntegration extends EndpointRouteBuilder {
                           throw new SbomValidationException(
                               "Failed to parse SBOM " + parseEx.getMessage(), parseEx);
                         }
-                      }));
+                      },
+                      (a, b) -> a,
+                      LinkedHashMap::new));
       exchange.getIn().setBody(trees);
     } catch (DetailedException e) {
       throw e;
@@ -433,7 +436,11 @@ public class ExhortIntegration extends EndpointRouteBuilder {
 
   public Map<String, AnalysisReport> transformBatchAnalysisReportList(
       @Body List<Map.Entry<String, AnalysisReport>> reports) {
-    return reports.stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    return reports.stream()
+        .sorted(Map.Entry.comparingByKey())
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey, Map.Entry::getValue, (a, b) -> a, LinkedHashMap::new));
   }
 
   private void setProviderConfiguration(Exchange exchange) {

--- a/src/main/java/io/github/guacsec/trustifyda/integration/report/ReportTransformer.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/report/ReportTransformer.java
@@ -17,6 +17,7 @@
 
 package io.github.guacsec.trustifyda.integration.report;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -73,7 +74,11 @@ public class ReportTransformer {
       @Header(Constants.VERBOSE_MODE_HEADER) Boolean verbose) {
     return reports.entrySet().stream()
         .collect(
-            Collectors.toMap(Map.Entry::getKey, e -> filterVerboseResult(e.getValue(), verbose)));
+            Collectors.toMap(
+                Map.Entry::getKey,
+                e -> filterVerboseResult(e.getValue(), verbose),
+                (a, b) -> a,
+                LinkedHashMap::new));
   }
 
   public void attachHtmlReport(Exchange exchange) {

--- a/src/test/java/io/github/guacsec/trustifyda/integration/AnalysisTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/AnalysisTest.java
@@ -36,7 +36,9 @@ import java.net.http.HttpClient;
 import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -665,6 +667,36 @@ public class AnalysisTest extends AbstractAnalysisTest {
     assertJson("reports/batch_report.json", body);
     verifyTrustifyRequest(OK_TOKEN, 3);
     verifyLicensesRequest(3);
+  }
+
+  /** Verifies that batch analysis response keys are sorted alphabetically. */
+  @Test
+  public void testBatchResponseKeysAreSorted() throws Exception {
+    stubAllProviders();
+
+    var body =
+        given()
+            .header(CONTENT_TYPE, getContentType(CYCLONEDX))
+            .header("Accept", MediaType.APPLICATION_JSON)
+            .header(Constants.TRUSTIFY_TOKEN_HEADER, OK_TOKEN)
+            .body(loadBatchSBOMFile(CYCLONEDX))
+            .when()
+            .post("/api/v5/batch-analysis")
+            .then()
+            .assertThat()
+            .statusCode(200)
+            .contentType(MediaType.APPLICATION_JSON)
+            .extract()
+            .body()
+            .asString();
+
+    // Parse the response preserving key order
+    Map<String, Object> result =
+        MAPPER.readValue(body, new TypeReference<LinkedHashMap<String, Object>>() {});
+    List<String> keys = new ArrayList<>(result.keySet());
+    List<String> sortedKeys = new ArrayList<>(keys);
+    Collections.sort(sortedKeys);
+    assertEquals(sortedKeys, keys, "Batch analysis response keys should be in alphabetical order");
   }
 
   private void assertScanned(Scanned scanned) {


### PR DESCRIPTION
## Summary
- Replace `HashMap`-producing `Collectors.toMap()` calls with `LinkedHashMap` suppliers in `ExhortIntegration.processBatchAnalysisRequest` and `ExhortIntegration.transformBatchAnalysisReportList`
- Sort batch entries alphabetically by key in `transformBatchAnalysisReportList` to guarantee deterministic tab ordering in the HTML report
- Fix `ReportTransformer.batchFilterVerboseResult` to also use `LinkedHashMap`, preventing it from re-scrambling the sorted order
- Add test `testBatchResponseKeysAreSorted` verifying batch response keys are in alphabetical order

Implements [TC-4664](https://redhat.atlassian.net/browse/TC-4664)

## Test plan
- [x] New test `testBatchResponseKeysAreSorted` passes — verifies keys are alphabetically ordered
- [x] Existing batch analysis tests continue to pass
- [x] Code formatted with `mvn spotless:apply`

[TC-4664]: https://redhat.atlassian.net/browse/TC-4664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Ensure deterministic, alphabetically ordered batch analysis responses and preserve that order through the integration and reporting pipeline.

Bug Fixes:
- Preserve insertion order when building batch analysis trees by collecting into LinkedHashMap instead of HashMap.
- Guarantee deterministic, alphabetically ordered batch analysis reports and maintain that ordering when transforming report lists.
- Prevent verbose-result filtering from reordering batch report entries by using LinkedHashMap for the filtered output.

Tests:
- Add an integration test that verifies batch analysis response keys are returned in alphabetical order.