### PR TITLE
feat: add Codecov integration with JaCoCo coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - '*'
@@ -33,6 +36,8 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     name: Integration Tests
+    permissions:
+      id-token: write
     needs: commitlint
     steps:
       - name: Checkout
@@ -49,3 +54,9 @@ jobs:
         env:
           GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          flags: integration-tests
+          files: target/site/jacoco/jacoco.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+
+ignore:
+  - "src/test/**"
+  - "target/**"
+
+flags:
+  integration-tests:
+    carryforward: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <spotless-maven-plugin.version>2.37.0</spotless-maven-plugin.version>
     <surefire-plugin.version>3.0.0</surefire-plugin.version>
+    <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
     <deploy-plugin.version>3.1.1</deploy-plugin.version>
 
     <!-- Dependencies -->
@@ -461,6 +462,26 @@
         <configuration>
           <skip>true</skip>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
## Summary

- Add **JaCoCo** Maven plugin for coverage report generation
- Add **push-to-main trigger** to CI workflow (previously only ran on PRs — needed for Codecov baseline)
- Add **Codecov upload** step using OIDC authentication (no secret needed)
- Add `codecov.yml` with informational status checks, `unit-tests` flag with carryforward

## Changes

| File | Change |
|------|--------|
| `pom.xml` | Add `jacoco-maven-plugin` 0.8.14 with `prepare-agent` + `report` goals |
| `.github/workflows/ci.yaml` | Add `push: branches: [main]` trigger, `permissions: id-token: write`, Codecov upload step |
| `codecov.yml` | Coverage config: informational checks, flag setup, ignore patterns |

## Manual follow-up

After merging:
1. Go to https://app.codecov.io/gh/guacsec/trustify-dependency-analytics
2. Click the **Flags** tab
3. Click **Enable flag analytics**

Ref: [COVERPORT-255](https://redhat.atlassian.net/browse/COVERPORT-255)

[COVERPORT-255]: https://redhat.atlassian.net/browse/COVERPORT-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Integrate JaCoCo code coverage reporting and Codecov uploads into the build and CI pipelines.

Build:
- Add JaCoCo Maven plugin configuration to generate coverage reports during the Maven verify phase.

CI:
- Extend CI workflow to run on pushes to main, grant OIDC permissions, and upload JaCoCo coverage reports to Codecov using a unit-tests flag and repository slug configuration.