### PR TITLE
feat(api): surface recommendations as provider-level map grouped by source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <deploy-plugin.version>3.1.1</deploy-plugin.version>
 
     <!-- Dependencies -->
-    <trustify-da-api.version>2.0.8-SNAPSHOT</trustify-da-api.version>
+    <trustify-da-api.version>2.0.8</trustify-da-api.version>
     <cyclonedx.version>11.0.1</cyclonedx.version>
     <sentry.version>7.8.0</sentry.version>
     <spdx.version>2.0.2</spdx.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
     <deploy-plugin.version>3.1.1</deploy-plugin.version>
 
     <!-- Dependencies -->
-    <trustify-da-api.version>2.0.7</trustify-da-api.version>
+    <trustify-da-api.version>2.0.8-SNAPSHOT</trustify-da-api.version>
     <cyclonedx.version>11.0.1</cyclonedx.version>
     <sentry.version>7.8.0</sentry.version>
     <spdx.version>2.0.2</spdx.version>

--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/ProviderResponseHandler.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/ProviderResponseHandler.java
@@ -41,6 +41,9 @@ import io.github.guacsec.trustifyda.api.v5.DependencyReport;
 import io.github.guacsec.trustifyda.api.v5.Issue;
 import io.github.guacsec.trustifyda.api.v5.ProviderReport;
 import io.github.guacsec.trustifyda.api.v5.ProviderStatus;
+import io.github.guacsec.trustifyda.api.v5.RecommendationReport;
+import io.github.guacsec.trustifyda.api.v5.RecommendationSource;
+import io.github.guacsec.trustifyda.api.v5.RecommendationSummary;
 import io.github.guacsec.trustifyda.api.v5.Source;
 import io.github.guacsec.trustifyda.api.v5.SourceSummary;
 import io.github.guacsec.trustifyda.api.v5.TransitiveDependencyReport;
@@ -188,24 +191,19 @@ public abstract class ProviderResponseHandler {
   }
 
   /**
-   * Groups PackageItems by source from their issues. Each PackageItem can have issues from
-   * different sources, so we group them accordingly while preserving recommendations.
+   * Groups PackageItems by vulnerability source from their issues. Each PackageItem can have issues
+   * from different sources, so we group them accordingly. Recommendations are not propagated into
+   * vulnerability sources — they are handled separately via the provider-level recommendations map.
    */
   private Map<String, Map<String, PackageItem>> groupPackageItemsBySource(
-      Map<String, PackageItem> pkgItems, String defaultSource) {
+      Map<String, PackageItem> pkgItems) {
     Map<String, Map<String, PackageItem>> sourcesData = new HashMap<>();
     if (pkgItems == null) {
       return sourcesData;
     }
 
-    var recommendations =
-        pkgItems.values().stream()
-            .filter(item -> item.recommendation() != null)
-            .collect(Collectors.toMap(PackageItem::packageRef, PackageItem::recommendation));
-
     pkgItems.forEach(
         (packageRef, packageItem) -> {
-          // If there are issues, group by their source
           if (packageItem.issues() != null && !packageItem.issues().isEmpty()) {
             packageItem
                 .issues()
@@ -216,56 +214,32 @@ public abstract class ProviderResponseHandler {
                         return;
                       }
                       var sourceItems = sourcesData.computeIfAbsent(source, k -> new HashMap<>());
-                      // Get or create PackageItem for this source and package
                       var existingItem = sourceItems.get(packageRef);
-                      var recommendation = recommendations.get(packageRef);
                       if (existingItem == null) {
-                        // Create new PackageItem with this issue and the recommendation
                         sourceItems.put(
                             packageRef,
                             new PackageItem(
                                 packageRef,
-                                recommendation,
+                                packageItem.recommendation(),
                                 new ArrayList<>(List.of(issue)),
-                                packageItem.warnings()));
+                                packageItem.warnings(),
+                                packageItem.recommendationSource()));
                       } else {
-                        // Add issue to existing PackageItem if not already present
                         if (!existingItem.issues().contains(issue)) {
                           var updatedIssues = new ArrayList<>(existingItem.issues());
                           updatedIssues.add(issue);
-
                           sourceItems.put(
                               packageRef,
                               new PackageItem(
                                   packageRef,
-                                  recommendation,
+                                  packageItem.recommendation(),
                                   updatedIssues,
-                                  packageItem.warnings()));
+                                  packageItem.warnings(),
+                                  packageItem.recommendationSource()));
                         }
                       }
                     });
           }
-        });
-    if (sourcesData.isEmpty() && !recommendations.isEmpty()) {
-      sourcesData.put(defaultSource, new HashMap<>());
-    }
-    sourcesData.forEach(
-        (source, items) -> {
-          recommendations.forEach(
-              (packageRef, recommendation) -> {
-                if (!items.containsKey(packageRef)) {
-                  var originalItem = pkgItems.get(packageRef);
-                  items.put(
-                      packageRef,
-                      new PackageItem(
-                          packageRef,
-                          recommendation,
-                          Collections.emptyList(),
-                          originalItem != null
-                              ? originalItem.warnings()
-                              : Collections.emptyList()));
-                }
-              });
         });
     return sourcesData;
   }
@@ -278,8 +252,7 @@ public abstract class ProviderResponseHandler {
     if (response.status() != null && response.pkgItems() == null) {
       return new ProviderReport().status(response.status()).sources(Collections.emptyMap());
     }
-    var providerName = getProviderName(exchange);
-    var sourcesData = groupPackageItemsBySource(response.pkgItems(), providerName);
+    var sourcesData = groupPackageItemsBySource(response.pkgItems());
 
     Map<String, Source> reports = new HashMap<>();
     sourcesData
@@ -290,7 +263,13 @@ public abstract class ProviderResponseHandler {
     if (response.status() != null) {
       response.status().warnings(warnings);
     }
-    return new ProviderReport().status(response.status()).sources(reports);
+
+    var recommendations = buildRecommendationsMap(response.pkgItems());
+
+    return new ProviderReport()
+        .status(response.status())
+        .sources(reports)
+        .recommendations(recommendations);
   }
 
   public ProviderResponse filterCves(Exchange exchange) {
@@ -319,7 +298,8 @@ public abstract class ProviderResponseHandler {
                           entry.getKey(),
                           item.recommendation(),
                           filteredIssues,
-                          item.warnings() == null ? Collections.emptyList() : item.warnings());
+                          item.warnings() == null ? Collections.emptyList() : item.warnings(),
+                          item.recommendationSource());
                     }));
     return new ProviderResponse(filteredItems, response.status());
   }
@@ -478,6 +458,41 @@ public abstract class ProviderResponseHandler {
         sourceReport.stream().filter(s -> s.getRecommendation() != null).count();
     counter.recommendations.set(recommendationsCount.intValue());
     return counter.getSummary();
+  }
+
+  /**
+   * Builds the provider-level recommendations map from all PackageItems that have recommendations.
+   * Groups recommendations by their source name (e.g. "trusted-content", "hardened-images").
+   */
+  private Map<String, RecommendationSource> buildRecommendationsMap(
+      Map<String, PackageItem> pkgItems) {
+    if (pkgItems == null) {
+      return Collections.emptyMap();
+    }
+    Map<String, List<RecommendationReport>> bySource = new HashMap<>();
+    pkgItems.forEach(
+        (packageRef, item) -> {
+          if (item.recommendation() == null || item.recommendation().packageName() == null) {
+            return;
+          }
+          String sourceName = item.recommendationSource();
+          if (sourceName == null) {
+            return;
+          }
+          var recReport =
+              new RecommendationReport()
+                  .ref(new PackageRef(packageRef))
+                  .recommendation(item.recommendation().packageName());
+          bySource.computeIfAbsent(sourceName, k -> new ArrayList<>()).add(recReport);
+        });
+
+    Map<String, RecommendationSource> result = new HashMap<>();
+    bySource.forEach(
+        (sourceName, reports) -> {
+          var summary = new RecommendationSummary().total(reports.size());
+          result.put(sourceName, new RecommendationSource().summary(summary).dependencies(reports));
+        });
+    return result;
   }
 
   private void incrementCounter(PackageItem item, VulnerabilityCounter counter, boolean isDirect) {

--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/ProviderResponseHandler.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/ProviderResponseHandler.java
@@ -467,7 +467,7 @@ public abstract class ProviderResponseHandler {
   private Map<String, RecommendationSource> buildRecommendationsMap(
       Map<String, PackageItem> pkgItems) {
     if (pkgItems == null) {
-      return Collections.emptyMap();
+      return new HashMap<>();
     }
     Map<String, List<RecommendationReport>> bySource = new HashMap<>();
     pkgItems.forEach(

--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/RecommendationAggregation.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/RecommendationAggregation.java
@@ -157,15 +157,19 @@ public class RecommendationAggregation implements AggregationStrategy {
                       key.ref(),
                       recommendation,
                       issues,
-                      pkgItem != null ? pkgItem.warnings() : Collections.emptyList()));
+                      pkgItem != null ? pkgItem.warnings() : Collections.emptyList(),
+                      value.sourceName()));
         });
   }
 
   private Recommendation toRecommendation(IndexedRecommendation recommendation) {
     if (recommendation.vulnerabilities() == null) {
-      return new Recommendation(recommendation.packageName(), Collections.emptyList());
+      return new Recommendation(
+          recommendation.packageName(), Collections.emptyList(), recommendation.sourceName());
     }
     return new Recommendation(
-        recommendation.packageName(), recommendation.vulnerabilities().values().stream().toList());
+        recommendation.packageName(),
+        recommendation.vulnerabilities().values().stream().toList(),
+        recommendation.sourceName());
   }
 }

--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/RecommendationAggregation.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/RecommendationAggregation.java
@@ -164,12 +164,9 @@ public class RecommendationAggregation implements AggregationStrategy {
 
   private Recommendation toRecommendation(IndexedRecommendation recommendation) {
     if (recommendation.vulnerabilities() == null) {
-      return new Recommendation(
-          recommendation.packageName(), Collections.emptyList(), recommendation.sourceName());
+      return new Recommendation(recommendation.packageName(), Collections.emptyList());
     }
     return new Recommendation(
-        recommendation.packageName(),
-        recommendation.vulnerabilities().values().stream().toList(),
-        recommendation.sourceName());
+        recommendation.packageName(), recommendation.vulnerabilities().values().stream().toList());
   }
 }

--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyIntegration.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyIntegration.java
@@ -389,7 +389,8 @@ public class TrustifyIntegration extends EndpointRouteBuilder {
               var recommendationPkgRef = pkgRef.toGav();
               if (!sourcePkgRef.equals(recommendationPkgRef)) {
                 result.put(
-                    new PackageRef(e.getKey()), new IndexedRecommendation(pkgRef, vulnerabilities));
+                    new PackageRef(e.getKey()),
+                    new IndexedRecommendation(pkgRef, vulnerabilities, "trusted-content"));
               }
             });
     return result;
@@ -407,7 +408,8 @@ public class TrustifyIntegration extends EndpointRouteBuilder {
 
     var recommendedUBIPurl = ubiRecommendation.mapping().get(pkgRef.name());
     if (recommendedUBIPurl != null) {
-      var recommendation = new IndexedRecommendation(new PackageRef(recommendedUBIPurl), null);
+      var recommendation =
+          new IndexedRecommendation(new PackageRef(recommendedUBIPurl), null, "hardened-images");
       return Collections.singletonMap(pkgRef, recommendation);
     }
     return Collections.emptyMap();

--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyIntegration.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyIntegration.java
@@ -91,6 +91,8 @@ public class TrustifyIntegration extends EndpointRouteBuilder {
   // see https://www.cisa.gov/sites/default/files/2023-01/VEX_Status_Justification_Jun22.pdf
   private static final List<String> FIXED_STATUSES = List.of("NotAffected", "Fixed");
   private static final String OCI_PURL_TYPE = "oci";
+  private static final String TRUSTED_CONTENT_SOURCE = "trusted-content";
+  private static final String HARDENED_IMAGES_SOURCE = "hardened-images";
 
   @Override
   public void configure() throws Exception {
@@ -390,7 +392,7 @@ public class TrustifyIntegration extends EndpointRouteBuilder {
               if (!sourcePkgRef.equals(recommendationPkgRef)) {
                 result.put(
                     new PackageRef(e.getKey()),
-                    new IndexedRecommendation(pkgRef, vulnerabilities, "trusted-content"));
+                    new IndexedRecommendation(pkgRef, vulnerabilities, TRUSTED_CONTENT_SOURCE));
               }
             });
     return result;
@@ -409,7 +411,7 @@ public class TrustifyIntegration extends EndpointRouteBuilder {
     var recommendedUBIPurl = ubiRecommendation.mapping().get(pkgRef.name());
     if (recommendedUBIPurl != null) {
       var recommendation =
-          new IndexedRecommendation(new PackageRef(recommendedUBIPurl), null, "hardened-images");
+          new IndexedRecommendation(new PackageRef(recommendedUBIPurl), null, HARDENED_IMAGES_SOURCE);
       return Collections.singletonMap(pkgRef, recommendation);
     }
     return Collections.emptyMap();

--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyIntegration.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyIntegration.java
@@ -411,7 +411,8 @@ public class TrustifyIntegration extends EndpointRouteBuilder {
     var recommendedUBIPurl = ubiRecommendation.mapping().get(pkgRef.name());
     if (recommendedUBIPurl != null) {
       var recommendation =
-          new IndexedRecommendation(new PackageRef(recommendedUBIPurl), null, HARDENED_IMAGES_SOURCE);
+          new IndexedRecommendation(
+              new PackageRef(recommendedUBIPurl), null, HARDENED_IMAGES_SOURCE);
       return Collections.singletonMap(pkgRef, recommendation);
     }
     return Collections.emptyMap();

--- a/src/main/java/io/github/guacsec/trustifyda/integration/registry/RegistryEnrichmentService.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/registry/RegistryEnrichmentService.java
@@ -29,6 +29,9 @@ import io.github.guacsec.trustifyda.api.PackageRef;
 import io.github.guacsec.trustifyda.api.v5.AnalysisReport;
 import io.github.guacsec.trustifyda.api.v5.DependencyReport;
 import io.github.guacsec.trustifyda.api.v5.ProviderReport;
+import io.github.guacsec.trustifyda.api.v5.RecommendationReport;
+import io.github.guacsec.trustifyda.api.v5.RecommendationSource;
+import io.github.guacsec.trustifyda.api.v5.RecommendationSummary;
 import io.github.guacsec.trustifyda.api.v5.Remediation;
 import io.github.guacsec.trustifyda.api.v5.RemediationTrustedContent;
 import io.github.guacsec.trustifyda.api.v5.Source;
@@ -38,6 +41,7 @@ import io.github.guacsec.trustifyda.model.DependencyTree;
 class RegistryEnrichmentService {
 
   private static final String HASH_ALG_SHA256 = "SHA-256";
+  private static final String TRUSTED_LIBRARIES_SOURCE = "trusted-libraries";
 
   void enrichReport(
       AnalysisReport report,
@@ -110,7 +114,11 @@ class RegistryEnrichmentService {
                     issue -> issue.remediation(new Remediation().trustedContent(trustedContent)));
           }
 
+          // Backward compat: set deprecated per-dependency recommendation
           depReport.recommendation(recommendedRef.get());
+
+          // Populate provider-level recommendations map
+          addToRecommendationsMap(providerReport, depReport.getRef(), recommendedRef.get());
         }
       }
     }
@@ -141,6 +149,7 @@ class RegistryEnrichmentService {
         continue;
       }
 
+      // Backward compat: add deprecated per-dependency recommendation to a source
       var depReport = new DependencyReport().ref(pkgRef).recommendation(recommendedRef.get());
 
       for (var providerEntry : providers.entrySet()) {
@@ -164,9 +173,34 @@ class RegistryEnrichmentService {
             break;
           }
         }
+
+        // Populate provider-level recommendations map
+        addToRecommendationsMap(providerReport, pkgRef, recommendedRef.get());
         break;
       }
     }
+  }
+
+  /**
+   * Adds a recommendation entry to the provider-level "trusted-libraries" recommendation source.
+   */
+  private void addToRecommendationsMap(
+      ProviderReport providerReport, PackageRef ref, PackageRef recommendedRef) {
+    if (providerReport.getRecommendations() == null) {
+      providerReport.recommendations(new HashMap<>());
+    }
+    var recSource =
+        providerReport
+            .getRecommendations()
+            .computeIfAbsent(
+                TRUSTED_LIBRARIES_SOURCE,
+                k ->
+                    new RecommendationSource()
+                        .summary(new RecommendationSummary().total(0))
+                        .dependencies(new ArrayList<>()));
+    var recReport = new RecommendationReport().ref(ref).recommendation(recommendedRef);
+    recSource.addDependenciesItem(recReport);
+    recSource.getSummary().total(recSource.getDependencies().size());
   }
 
   private void recountRecommendations(Map<String, ProviderReport> providers) {

--- a/src/main/java/io/github/guacsec/trustifyda/model/PackageItem.java
+++ b/src/main/java/io/github/guacsec/trustifyda/model/PackageItem.java
@@ -22,5 +22,16 @@ import java.util.List;
 import io.github.guacsec.trustifyda.api.v5.Issue;
 import io.github.guacsec.trustifyda.model.trustify.Recommendation;
 
+/** Aggregated data for a single package: its recommendation, vulnerability issues, and warnings. */
 public record PackageItem(
-    String packageRef, Recommendation recommendation, List<Issue> issues, List<String> warnings) {}
+    String packageRef,
+    Recommendation recommendation,
+    List<Issue> issues,
+    List<String> warnings,
+    String recommendationSource) {
+
+  public PackageItem(
+      String packageRef, Recommendation recommendation, List<Issue> issues, List<String> warnings) {
+    this(packageRef, recommendation, issues, warnings, null);
+  }
+}

--- a/src/main/java/io/github/guacsec/trustifyda/model/trustify/IndexedRecommendation.java
+++ b/src/main/java/io/github/guacsec/trustifyda/model/trustify/IndexedRecommendation.java
@@ -22,9 +22,14 @@ import java.util.Map;
 import io.github.guacsec.trustifyda.api.PackageRef;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+/** An intermediate recommendation model used during aggregation, before conversion to API types. */
 @RegisterForReflection
 public record IndexedRecommendation(
-    PackageRef packageName, Map<String, Vulnerability> vulnerabilities) {
+    PackageRef packageName, Map<String, Vulnerability> vulnerabilities, String sourceName) {
+
+  public IndexedRecommendation(PackageRef packageName, Map<String, Vulnerability> vulnerabilities) {
+    this(packageName, vulnerabilities, null);
+  }
 
   public static Builder builder() {
     return new Builder();
@@ -34,6 +39,8 @@ public record IndexedRecommendation(
     public PackageRef packageName;
 
     public Map<String, Vulnerability> vulnerabilities;
+
+    public String sourceName;
 
     public Builder packageName(PackageRef packageName) {
       this.packageName = packageName;
@@ -45,8 +52,13 @@ public record IndexedRecommendation(
       return this;
     }
 
+    public Builder sourceName(String sourceName) {
+      this.sourceName = sourceName;
+      return this;
+    }
+
     public IndexedRecommendation build() {
-      return new IndexedRecommendation(packageName, vulnerabilities);
+      return new IndexedRecommendation(packageName, vulnerabilities, sourceName);
     }
   }
 }

--- a/src/main/java/io/github/guacsec/trustifyda/model/trustify/Recommendation.java
+++ b/src/main/java/io/github/guacsec/trustifyda/model/trustify/Recommendation.java
@@ -24,9 +24,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.github.guacsec.trustifyda.api.PackageRef;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+/** A recommendation mapping a dependency to its trusted-content alternative. */
 @RegisterForReflection
 public record Recommendation(
-    @JsonProperty("package") PackageRef packageName, List<Vulnerability> vulnerabilities) {
+    @JsonProperty("package") PackageRef packageName,
+    List<Vulnerability> vulnerabilities,
+    String sourceName) {
+
+  public Recommendation(PackageRef packageName, List<Vulnerability> vulnerabilities) {
+    this(packageName, vulnerabilities, null);
+  }
 
   public static Builder builder() {
     return new Builder();
@@ -36,6 +43,8 @@ public record Recommendation(
     public PackageRef packageName;
 
     public List<Vulnerability> vulnerabilities;
+
+    public String sourceName;
 
     public Builder packageName(PackageRef packageName) {
       this.packageName = packageName;
@@ -47,8 +56,13 @@ public record Recommendation(
       return this;
     }
 
+    public Builder sourceName(String sourceName) {
+      this.sourceName = sourceName;
+      return this;
+    }
+
     public Recommendation build() {
-      return new Recommendation(packageName, vulnerabilities);
+      return new Recommendation(packageName, vulnerabilities, sourceName);
     }
   }
 }

--- a/src/main/java/io/github/guacsec/trustifyda/model/trustify/Recommendation.java
+++ b/src/main/java/io/github/guacsec/trustifyda/model/trustify/Recommendation.java
@@ -27,13 +27,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 /** A recommendation mapping a dependency to its trusted-content alternative. */
 @RegisterForReflection
 public record Recommendation(
-    @JsonProperty("package") PackageRef packageName,
-    List<Vulnerability> vulnerabilities,
-    String sourceName) {
-
-  public Recommendation(PackageRef packageName, List<Vulnerability> vulnerabilities) {
-    this(packageName, vulnerabilities, null);
-  }
+    @JsonProperty("package") PackageRef packageName, List<Vulnerability> vulnerabilities) {
 
   public static Builder builder() {
     return new Builder();
@@ -43,8 +37,6 @@ public record Recommendation(
     public PackageRef packageName;
 
     public List<Vulnerability> vulnerabilities;
-
-    public String sourceName;
 
     public Builder packageName(PackageRef packageName) {
       this.packageName = packageName;
@@ -56,13 +48,8 @@ public record Recommendation(
       return this;
     }
 
-    public Builder sourceName(String sourceName) {
-      this.sourceName = sourceName;
-      return this;
-    }
-
     public Recommendation build() {
-      return new Recommendation(packageName, vulnerabilities, sourceName);
+      return new Recommendation(packageName, vulnerabilities);
     }
   }
 }

--- a/src/test/java/io/github/guacsec/trustifyda/integration/AnalysisTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/AnalysisTest.java
@@ -227,6 +227,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
 
     body = replaceMockedDepsDevSourceUrl(body);
     assertJson("reports/report.json", body);
+    assertProviderRecommendations(body, TRUSTIFY_PROVIDER, "trusted-content", 9);
     verifyTrustifyRequest(TRUSTIFY_TOKEN);
     verifyRecommendRequest();
     verifyLicensesRequest(1);
@@ -345,6 +346,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .asPrettyString();
     assertRecommendations(body, TRUSTIFY_PROVIDER, CSAF_SOURCE, 0);
     assertRecommendations(body, TRUSTIFY_PROVIDER, OSV_SOURCE, 0);
+    assertProviderRecommendationsEmpty(body, TRUSTIFY_PROVIDER);
     verifyTrustifyRequest(TRUSTIFY_TOKEN);
     verifyNoInteractionsWithRecommend();
   }
@@ -373,6 +375,7 @@ public class AnalysisTest extends AbstractAnalysisTest {
             .asPrettyString();
     body = replaceMockedDepsDevSourceUrl(body);
     assertJson("reports/report.json", body);
+    assertProviderRecommendations(body, TRUSTIFY_PROVIDER, "trusted-content", 9);
     verifyTrustifyRequest(OK_TOKEN);
     verifyLicensesRequest(1);
   }
@@ -745,6 +748,38 @@ public class AnalysisTest extends AbstractAnalysisTest {
               .get(source)
               .getSummary()
               .getRecommendations());
+    } catch (IOException e) {
+      fail("Failed to read report: " + e.getMessage());
+    }
+  }
+
+  private void assertProviderRecommendations(
+      String body, String provider, String recommendationSource, int expectedTotal) {
+    try {
+      var report = MAPPER.readValue(body, AnalysisReport.class);
+      var providerReport = report.getProviders().get(provider);
+      assertNotNull(providerReport, "Provider not found: " + provider);
+      assertNotNull(
+          providerReport.getRecommendations(),
+          "Provider-level recommendations map should not be null");
+      var recSource = providerReport.getRecommendations().get(recommendationSource);
+      assertNotNull(recSource, "Recommendation source not found: " + recommendationSource);
+      assertEquals(expectedTotal, recSource.getSummary().getTotal());
+      assertEquals(expectedTotal, recSource.getDependencies().size());
+    } catch (IOException e) {
+      fail("Failed to read report: " + e.getMessage());
+    }
+  }
+
+  private void assertProviderRecommendationsEmpty(String body, String provider) {
+    try {
+      var report = MAPPER.readValue(body, AnalysisReport.class);
+      var providerReport = report.getProviders().get(provider);
+      assertNotNull(providerReport, "Provider not found: " + provider);
+      assertTrue(
+          providerReport.getRecommendations() == null
+              || providerReport.getRecommendations().isEmpty(),
+          "Provider-level recommendations map should be empty");
     } catch (IOException e) {
       fail("Failed to read report: " + e.getMessage());
     }

--- a/src/test/java/io/github/guacsec/trustifyda/integration/providers/ProviderResponseHandlerTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/providers/ProviderResponseHandlerTest.java
@@ -354,6 +354,7 @@ public class ProviderResponseHandlerTest {
     assertNotNull(response.getRecommendations());
     assertTrue(response.getRecommendations().containsKey("trusted-content"));
     var recSource = response.getRecommendations().get("trusted-content");
+
     assertEquals(2, recSource.getDependencies().size());
     assertEquals(2, recSource.getSummary().getTotal());
   }
@@ -388,6 +389,7 @@ public class ProviderResponseHandlerTest {
     assertNotNull(response.getRecommendations());
     var recSource = response.getRecommendations().get("trusted-content");
     assertNotNull(recSource);
+
     assertEquals(1, recSource.getDependencies().size());
     assertEquals(1, recSource.getSummary().getTotal());
 
@@ -434,6 +436,7 @@ public class ProviderResponseHandlerTest {
     assertNotNull(response.getRecommendations());
     var recSource = response.getRecommendations().get("trusted-content");
     assertNotNull(recSource);
+
     assertEquals(1, recSource.getDependencies().size());
   }
 
@@ -471,6 +474,7 @@ public class ProviderResponseHandlerTest {
     assertEquals(2, response.getRecommendations().size());
     assertTrue(response.getRecommendations().containsKey("trusted-content"));
     assertTrue(response.getRecommendations().containsKey("hardened-images"));
+
     assertEquals(1, response.getRecommendations().get("trusted-content").getSummary().getTotal());
     assertEquals(1, response.getRecommendations().get("hardened-images").getSummary().getTotal());
   }

--- a/src/test/java/io/github/guacsec/trustifyda/integration/providers/ProviderResponseHandlerTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/providers/ProviderResponseHandlerTest.java
@@ -21,6 +21,7 @@ import static io.github.guacsec.trustifyda.model.trustify.Vulnerability.Justific
 import static io.github.guacsec.trustifyda.model.trustify.Vulnerability.StatusEnum.Fixed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -93,24 +94,6 @@ public class ProviderResponseHandlerTest {
 
   private static Stream<Arguments> getSummaryValues() {
     return Stream.of(
-        // Case 1: 0 issues 2 recommendations
-        Arguments.of(
-            Map.of(
-                "pkg:npm/aa@1",
-                    new PackageItem(
-                        "pkg:npm/aa@1",
-                        buildRecommendation("pkg:npm/aa@2", Collections.emptyMap()),
-                        Collections.emptyList(),
-                        Collections.emptyList()),
-                "pkg:npm/ab@1",
-                    new PackageItem(
-                        "pkg:npm/ab@1",
-                        buildRecommendation("pkg:npm/ab@2", Collections.emptyMap()),
-                        Collections.emptyList(),
-                        Collections.emptyList())),
-            tree().direct("aa").direct("ab").build(),
-            new SourceSummary().direct(0).total(0).dependencies(0).recommendations(2),
-            TEST_PROVIDER),
         // Case 2: 2 issues 0 recommendations 3 unscanned
         Arguments.of(
             Map.of(
@@ -182,7 +165,7 @@ public class ProviderResponseHandlerTest {
                 .total(1)
                 .medium(1)
                 .dependencies(1)
-                .recommendations(2)
+                .recommendations(1)
                 .remediations(1),
             TEST_SOURCE),
         // Case 4: 2 direct issues with 4 transitive
@@ -331,6 +314,194 @@ public class ProviderResponseHandlerTest {
     DependencyReport highest = getValidSource(response, TEST_SOURCE).getDependencies().get(0);
     assertEquals("ISSUE-002", highest.getHighestVulnerability().getId());
     assertEquals(9f, highest.getHighestVulnerability().getCvssScore());
+  }
+
+  /**
+   * Verifies that recommendation-only PackageItems populate the recommendations map, not sources.
+   */
+  @Test
+  public void testRecommendationsMapWithNoIssues() throws IOException {
+    // Given two packages with recommendations but no issues
+    Map<String, PackageItem> data =
+        Map.of(
+            "pkg:npm/aa@1",
+            new PackageItem(
+                "pkg:npm/aa@1",
+                buildRecommendation("pkg:npm/aa@2", Collections.emptyMap()),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                "trusted-content"),
+            "pkg:npm/ab@1",
+            new PackageItem(
+                "pkg:npm/ab@1",
+                buildRecommendation("pkg:npm/ab@2", Collections.emptyMap()),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                "trusted-content"));
+
+    ProviderResponseHandler handler = new TestResponseHandler();
+    // When building the report
+    ProviderReport response =
+        handler.buildReport(
+            Mockito.mock(Exchange.class),
+            new ProviderResponse(data, new ProviderStatus()),
+            tree().direct("aa").direct("ab").build());
+
+    // Then no vulnerability sources are created
+    assertTrue(response.getSources().isEmpty());
+
+    // Then the recommendations map contains the trusted-content source with 2 entries
+    assertNotNull(response.getRecommendations());
+    assertTrue(response.getRecommendations().containsKey("trusted-content"));
+    var recSource = response.getRecommendations().get("trusted-content");
+    assertEquals(2, recSource.getDependencies().size());
+    assertEquals(2, recSource.getSummary().getTotal());
+  }
+
+  /** Verifies that recommendations are not duplicated across vulnerability sources. */
+  @Test
+  public void testRecommendationsNotDuplicatedAcrossSources() throws IOException {
+    // Given a package with a recommendation and issues from two different sources
+    var issue1 = buildIssue(1, 5f);
+    issue1.setSource("source-a");
+    var issue2 = buildIssue(2, 7f);
+    issue2.setSource("source-b");
+    Map<String, PackageItem> data =
+        Map.of(
+            "pkg:npm/aa@1",
+            new PackageItem(
+                "pkg:npm/aa@1",
+                buildRecommendation("pkg:npm/aa@2", Collections.emptyMap()),
+                List.of(issue1, issue2),
+                Collections.emptyList(),
+                "trusted-content"));
+
+    ProviderResponseHandler handler = new TestResponseHandler();
+    // When building the report
+    ProviderReport response =
+        handler.buildReport(
+            Mockito.mock(Exchange.class),
+            new ProviderResponse(data, new ProviderStatus()),
+            tree().direct("aa").build());
+
+    // Then the recommendation appears once in the recommendations map
+    assertNotNull(response.getRecommendations());
+    var recSource = response.getRecommendations().get("trusted-content");
+    assertNotNull(recSource);
+    assertEquals(1, recSource.getDependencies().size());
+    assertEquals(1, recSource.getSummary().getTotal());
+
+    // Then DependencyReport.recommendation is still set for backward compat in each source
+    assertNotNull(response.getSources().get("source-a"));
+    assertEquals(1, response.getSources().get("source-a").getDependencies().size());
+    assertNotNull(
+        response.getSources().get("source-a").getDependencies().get(0).getRecommendation());
+    assertNotNull(response.getSources().get("source-b"));
+    assertEquals(1, response.getSources().get("source-b").getDependencies().size());
+    assertNotNull(
+        response.getSources().get("source-b").getDependencies().get(0).getRecommendation());
+  }
+
+  /** Verifies that DependencyReport.recommendation is populated for backward compatibility. */
+  @Test
+  public void testBackwardCompatRecommendation() throws IOException {
+    // Given a package with both issues and a recommendation
+    Map<String, PackageItem> data =
+        Map.of(
+            "pkg:npm/aa@1",
+            new PackageItem(
+                "pkg:npm/aa@1",
+                buildRecommendation("pkg:npm/aa@2", Collections.emptyMap()),
+                List.of(buildIssue(1, 5f)),
+                Collections.emptyList(),
+                "trusted-content"));
+
+    ProviderResponseHandler handler = new TestResponseHandler();
+    // When building the report
+    ProviderReport response =
+        handler.buildReport(
+            Mockito.mock(Exchange.class),
+            new ProviderResponse(data, new ProviderStatus()),
+            tree().direct("aa").build());
+
+    // Then DependencyReport.recommendation is set (backward compat)
+    var source = getValidSource(response, TEST_SOURCE);
+    assertEquals(1, source.getDependencies().size());
+    assertNotNull(source.getDependencies().get(0).getRecommendation());
+    assertEquals("pkg:npm/aa@2", source.getDependencies().get(0).getRecommendation().ref());
+
+    // Then the recommendations map also has the entry
+    assertNotNull(response.getRecommendations());
+    var recSource = response.getRecommendations().get("trusted-content");
+    assertNotNull(recSource);
+    assertEquals(1, recSource.getDependencies().size());
+  }
+
+  /** Verifies that recommendations from different sources have independent entries. */
+  @Test
+  public void testMultipleRecommendationSources() throws IOException {
+    // Given packages with recommendations from different sources
+    Map<String, PackageItem> data =
+        Map.of(
+            "pkg:npm/aa@1",
+            new PackageItem(
+                "pkg:npm/aa@1",
+                buildRecommendation("pkg:npm/aa@2", Collections.emptyMap()),
+                List.of(buildIssue(1, 5f)),
+                Collections.emptyList(),
+                "trusted-content"),
+            "pkg:oci/image@1",
+            new PackageItem(
+                "pkg:oci/image@1",
+                buildRecommendation("pkg:oci/image@2", Collections.emptyMap()),
+                List.of(buildIssue(2, 7f)),
+                Collections.emptyList(),
+                "hardened-images"));
+
+    ProviderResponseHandler handler = new TestResponseHandler();
+    // When building the report
+    ProviderReport response =
+        handler.buildReport(
+            Mockito.mock(Exchange.class),
+            new ProviderResponse(data, new ProviderStatus()),
+            tree().direct("aa").direct("image").build());
+
+    // Then the recommendations map has separate entries per source
+    assertNotNull(response.getRecommendations());
+    assertEquals(2, response.getRecommendations().size());
+    assertTrue(response.getRecommendations().containsKey("trusted-content"));
+    assertTrue(response.getRecommendations().containsKey("hardened-images"));
+    assertEquals(1, response.getRecommendations().get("trusted-content").getSummary().getTotal());
+    assertEquals(1, response.getRecommendations().get("hardened-images").getSummary().getTotal());
+  }
+
+  /** Verifies that PackageItems without a recommendationSource are excluded from the map. */
+  @Test
+  public void testRecommendationsWithoutSourceNameExcluded() throws IOException {
+    // Given a package with a recommendation but no source name
+    Map<String, PackageItem> data =
+        Map.of(
+            "pkg:npm/aa@1",
+            new PackageItem(
+                "pkg:npm/aa@1",
+                buildRecommendation("pkg:npm/aa@2", Collections.emptyMap()),
+                List.of(buildIssue(1, 5f)),
+                Collections.emptyList()));
+
+    ProviderResponseHandler handler = new TestResponseHandler();
+    // When building the report
+    ProviderReport response =
+        handler.buildReport(
+            Mockito.mock(Exchange.class),
+            new ProviderResponse(data, new ProviderStatus()),
+            tree().direct("aa").build());
+
+    // Then the recommendations map is empty (no source name)
+    assertTrue(response.getRecommendations().isEmpty());
+
+    // Then DependencyReport.recommendation is still set for backward compat
+    var source = getValidSource(response, TEST_SOURCE);
+    assertNotNull(source.getDependencies().get(0).getRecommendation());
   }
 
   private Source getValidSource(ProviderReport report, String sourceName) {

--- a/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/RecommendationAggregationTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/RecommendationAggregationTest.java
@@ -369,10 +369,18 @@ public class RecommendationAggregationTest {
 
   private static Map<PackageRef, IndexedRecommendation> createRecommendations(
       String packageRef, String recommendedPackage, Map<String, Vulnerability> vulnerabilities) {
+    return createRecommendations(packageRef, recommendedPackage, vulnerabilities, null);
+  }
+
+  private static Map<PackageRef, IndexedRecommendation> createRecommendations(
+      String packageRef,
+      String recommendedPackage,
+      Map<String, Vulnerability> vulnerabilities,
+      String sourceName) {
     Map<PackageRef, IndexedRecommendation> recommendations = new HashMap<>();
     PackageRef recPkgRef = new PackageRef(packageRef);
     IndexedRecommendation recommendation =
-        new IndexedRecommendation(new PackageRef(recommendedPackage), vulnerabilities);
+        new IndexedRecommendation(new PackageRef(recommendedPackage), vulnerabilities, sourceName);
     recommendations.put(recPkgRef, recommendation);
     return recommendations;
   }
@@ -469,6 +477,84 @@ public class RecommendationAggregationTest {
     ProviderResponse resultResponse = result.getIn().getBody(ProviderResponse.class);
     assertNotNull(resultResponse);
     testCase.verifier().accept(resultResponse);
+  }
+
+  @Test
+  void testSourceNamePreservedThroughAggregation() {
+    Exchange oldExchange = mock(Exchange.class);
+    Exchange newExchange = mock(Exchange.class);
+    Message oldMessage = createMessageWithBodyStorage();
+    Message newMessage = mock(Message.class);
+
+    oldMessage.setBody(new ProviderResponse(new HashMap<>(), null));
+    when(oldExchange.getIn()).thenReturn(oldMessage);
+    when(newExchange.getIn()).thenReturn(newMessage);
+    when(newMessage.getBody())
+        .thenReturn(
+            createRecommendations(
+                "pkg:npm/package1@1.0.0",
+                "pkg:npm/package1@2.0.0",
+                Collections.emptyMap(),
+                "trusted-content"));
+
+    Exchange result = aggregation.aggregate(oldExchange, newExchange);
+    ProviderResponse response = result.getIn().getBody(ProviderResponse.class);
+
+    PackageItem item = response.pkgItems().get("pkg:npm/package1@1.0.0");
+    assertNotNull(item);
+    assertEquals("trusted-content", item.recommendationSource());
+  }
+
+  @Test
+  void testNullSourceNamePreservedThroughAggregation() {
+    Exchange oldExchange = mock(Exchange.class);
+    Exchange newExchange = mock(Exchange.class);
+    Message oldMessage = createMessageWithBodyStorage();
+    Message newMessage = mock(Message.class);
+
+    oldMessage.setBody(new ProviderResponse(new HashMap<>(), null));
+    when(oldExchange.getIn()).thenReturn(oldMessage);
+    when(newExchange.getIn()).thenReturn(newMessage);
+    when(newMessage.getBody())
+        .thenReturn(
+            createRecommendations(
+                "pkg:npm/package1@1.0.0", "pkg:npm/package1@2.0.0", Collections.emptyMap()));
+
+    Exchange result = aggregation.aggregate(oldExchange, newExchange);
+    ProviderResponse response = result.getIn().getBody(ProviderResponse.class);
+
+    PackageItem item = response.pkgItems().get("pkg:npm/package1@1.0.0");
+    assertNotNull(item);
+    assertNull(item.recommendationSource());
+  }
+
+  @Test
+  void testSourceNamePreservedWhenMergingWithIssues() {
+    Exchange oldExchange = mock(Exchange.class);
+    Exchange newExchange = mock(Exchange.class);
+    Message oldMessage = createMessageWithBodyStorage();
+    Message newMessage = mock(Message.class);
+
+    oldMessage.setBody(
+        createProviderResponseWithIssues(List.of(createIssue("CVE-001", "Issue 1", 5.0f))));
+    when(oldExchange.getIn()).thenReturn(oldMessage);
+    when(newExchange.getIn()).thenReturn(newMessage);
+    when(newMessage.getBody())
+        .thenReturn(
+            createRecommendations(
+                "pkg:npm/package1@1.0.0",
+                "pkg:npm/package1@2.0.0",
+                Map.of("CVE-001", new Vulnerability("CVE-001", Fixed, NotProvided)),
+                "trusted-content"));
+
+    Exchange result = aggregation.aggregate(oldExchange, newExchange);
+    ProviderResponse response = result.getIn().getBody(ProviderResponse.class);
+
+    PackageItem item = response.pkgItems().get("pkg:npm/package1@1.0.0");
+    assertNotNull(item);
+    assertEquals("trusted-content", item.recommendationSource());
+    assertNotNull(item.recommendation());
+    assertEquals(1, item.issues().size());
   }
 
   /** Creates a mock Message that actually stores and retrieves the body. */

--- a/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandlerTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandlerTest.java
@@ -1079,7 +1079,7 @@ public class TrustifyResponseHandlerTest {
 
     PackageRef sbomRef = new PackageRef(sbomId);
     IndexedRecommendation recommendation =
-        new IndexedRecommendation(new PackageRef("pkg:oci/ubi@0.0.2"), null);
+        new IndexedRecommendation(new PackageRef("pkg:oci/ubi@0.0.2"), null, "hardened-images");
     assertEquals(1, recommendations.size());
     assertEquals(recommendation, recommendations.get(sbomRef));
   }

--- a/src/test/java/io/github/guacsec/trustifyda/integration/registry/RegistryEnrichmentServiceTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/registry/RegistryEnrichmentServiceTest.java
@@ -247,6 +247,46 @@ public class RegistryEnrichmentServiceTest {
     assertNotNull(deps.get(0).getRecommendation());
   }
 
+  @Test
+  void enrichPopulatesProviderLevelRecommendationsMap() {
+    var report = buildReportWithPypiDep("pkg:pypi/requests@2.31.0");
+    var tree = buildTree("pkg:pypi/requests@2.31.0", Map.of("SHA-256", "abc123"));
+
+    service.enrichReport(report, tree, PKG_PYPI_PREFIX, alwaysRecommend);
+
+    var providerReport = report.getProviders().values().iterator().next();
+    assertNotNull(providerReport.getRecommendations());
+    var recSource = providerReport.getRecommendations().get("trusted-libraries");
+    assertNotNull(recSource);
+    assertEquals(1, recSource.getDependencies().size());
+    assertEquals(1, recSource.getSummary().getTotal());
+    assertEquals("pkg:pypi/requests@2.31.0", recSource.getDependencies().get(0).getRef().ref());
+    assertNotNull(recSource.getDependencies().get(0).getRecommendation());
+  }
+
+  @Test
+  void enrichPopulatesRecommendationsMapForUnreportedDeps() {
+    var report = buildReportWithPypiDep("pkg:pypi/requests@2.31.0");
+
+    PackageRef requestsRef = PackageRef.builder().purl("pkg:pypi/requests@2.31.0").build();
+    PackageRef flaskRef = PackageRef.builder().purl("pkg:pypi/flask@3.0.0").build();
+    Map<PackageRef, DirectDependency> deps = new HashMap<>();
+    deps.put(requestsRef, DirectDependency.builder().ref(requestsRef).build());
+    deps.put(flaskRef, DirectDependency.builder().ref(flaskRef).build());
+
+    var tree =
+        DependencyTree.builder().dependencies(deps).componentHashes(Collections.emptyMap()).build();
+
+    service.enrichReport(report, tree, PKG_PYPI_PREFIX, alwaysRecommend);
+
+    var providerReport = report.getProviders().values().iterator().next();
+    assertNotNull(providerReport.getRecommendations());
+    var recSource = providerReport.getRecommendations().get("trusted-libraries");
+    assertNotNull(recSource);
+    assertEquals(2, recSource.getDependencies().size());
+    assertEquals(2, recSource.getSummary().getTotal());
+  }
+
   private AnalysisReport buildReportWithPypiDep(String purl) {
     return buildReportWithDep(purl);
   }

--- a/src/test/resources/__files/reports/batch_report.json
+++ b/src/test/resources/__files/reports/batch_report.json
@@ -30,7 +30,7 @@
               "medium": 2,
               "low": 0,
               "remediations": 2,
-              "recommendations": 6,
+              "recommendations": 0,
               "unscanned": 0
             },
             "dependencies": [
@@ -76,7 +76,6 @@
                     }
                   }
                 ],
-                "recommendation": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar",
                 "highestVulnerability": {
                   "id": "CVE-2024-1597",
                   "title": "pgjdbc SQL Injection via line comment generation",
@@ -201,7 +200,6 @@
                     }
                   }
                 ],
-                "recommendation": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar",
                 "highestVulnerability": {
                   "id": "CVE-2020-36518",
                   "title": "jackson-databind before 2.13.0 allows a Java StackOverflow exception and denial of service via a large depth of nested objects.",
@@ -220,22 +218,6 @@
                     }
                   }
                 }
-              },
-              {
-                "ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
-                "recommendation": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3.redhat-00002?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
-              },
-              {
-                "ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
-                "recommendation": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2.redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
-              },
-              {
-                "ref": "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final?type=jar",
-                "recommendation": "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
-              },
-              {
-                "ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar",
-                "recommendation": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5.redhat-00003?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
               }
             ]
           },
@@ -250,7 +232,7 @@
               "medium": 0,
               "low": 0,
               "remediations": 0,
-              "recommendations": 7,
+              "recommendations": 0,
               "unscanned": 0
             },
             "dependencies": [
@@ -285,7 +267,6 @@
                     }
                   }
                 ],
-                "recommendation": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar",
                 "highestVulnerability": {
                   "id": "CVE-2024-1597",
                   "title": "pgjdbc SQL Injection via line comment generation",
@@ -329,7 +310,6 @@
                     }
                   }
                 ],
-                "recommendation": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar",
                 "highestVulnerability": {
                   "id": "CVE-2024-2700",
                   "title": "Quarkus-core: leak of local configuration properties into quarkus applications",
@@ -341,7 +321,16 @@
                   ],
                   "unique": false
                 }
-              },
+              }
+            ]
+          }
+        },
+        "recommendations": {
+          "trusted-content": {
+            "summary": {
+              "total": 9
+            },
+            "dependencies": [
               {
                 "ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
                 "recommendation": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3.redhat-00002?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
@@ -349,6 +338,18 @@
               {
                 "ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
                 "recommendation": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2.redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
+              },
+              {
+                "ref": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final?type=jar",
+                "recommendation": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
+              },
+              {
+                "ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final?type=jar",
+                "recommendation": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
+              },
+              {
+                "ref": "pkg:maven/org.postgresql/postgresql@42.5.0?type=jar",
+                "recommendation": "pkg:maven/org.postgresql/postgresql@42.5.0.redhat-00001?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
               },
               {
                 "ref": "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final?type=jar",
@@ -361,6 +362,474 @@
               {
                 "ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar",
                 "recommendation": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5.redhat-00003?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
+              },
+              {
+                "ref": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final?type=jar",
+                "recommendation": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "licenses": [
+      {
+        "status": {
+          "ok": true,
+          "name": "deps.dev",
+          "code": 200,
+          "message": "OK",
+          "warnings": {}
+        },
+        "summary": {
+          "total": 12,
+          "concluded": 10,
+          "permissive": 8,
+          "weakCopyleft": 2,
+          "strongCopyleft": 0,
+          "unknown": 2,
+          "deprecated": 0,
+          "osiApproved": 10,
+          "fsfLibre": 10
+        },
+        "packages": {
+          "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final": {
+            "concluded": {
+              "identifiers": [
+                {
+                  "id": "Apache-2.0",
+                  "name": "Apache License 2.0",
+                  "isDeprecated": false,
+                  "isOsiApproved": true,
+                  "isFsfLibre": true,
+                  "category": "PERMISSIVE"
+                }
+              ],
+              "expression": "Apache-2.0",
+              "name": "Apache License 2.0",
+              "category": "PERMISSIVE",
+              "source": "deps.dev",
+              "sourceUrl": "https://api.deps.dev"
+            },
+            "evidence": [
+              {
+                "identifiers": [
+                  {
+                    "id": "Apache-2.0",
+                    "name": "Apache License 2.0",
+                    "isDeprecated": false,
+                    "isOsiApproved": true,
+                    "isFsfLibre": true,
+                    "category": "PERMISSIVE"
+                  }
+                ],
+                "expression": "Apache-2.0",
+                "name": "Apache License 2.0",
+                "category": "PERMISSIVE",
+                "source": "deps.dev",
+                "sourceUrl": "https://api.deps.dev"
+              }
+            ]
+          },
+          "pkg:maven/io.quarkus/quarkus-jdbc-h2@2.13.5.Final": {
+            "concluded": {
+              "identifiers": [
+                {
+                  "id": "Apache-2.0",
+                  "name": "Apache License 2.0",
+                  "isDeprecated": false,
+                  "isOsiApproved": true,
+                  "isFsfLibre": true,
+                  "category": "PERMISSIVE"
+                }
+              ],
+              "expression": "Apache-2.0",
+              "name": "Apache License 2.0",
+              "category": "PERMISSIVE",
+              "source": "deps.dev",
+              "sourceUrl": "https://api.deps.dev"
+            },
+            "evidence": [
+              {
+                "identifiers": [
+                  {
+                    "id": "Apache-2.0",
+                    "name": "Apache License 2.0",
+                    "isDeprecated": false,
+                    "isOsiApproved": true,
+                    "isFsfLibre": true,
+                    "category": "PERMISSIVE"
+                  }
+                ],
+                "expression": "Apache-2.0",
+                "name": "Apache License 2.0",
+                "category": "PERMISSIVE",
+                "source": "deps.dev",
+                "sourceUrl": "https://api.deps.dev"
+              }
+            ]
+          },
+          "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final": {
+            "concluded": {
+              "identifiers": [
+                {
+                  "id": "Apache-2.0",
+                  "name": "Apache License 2.0",
+                  "isDeprecated": false,
+                  "isOsiApproved": true,
+                  "isFsfLibre": true,
+                  "category": "PERMISSIVE"
+                }
+              ],
+              "expression": "Apache-2.0",
+              "name": "Apache License 2.0",
+              "category": "PERMISSIVE",
+              "source": "deps.dev",
+              "sourceUrl": "https://api.deps.dev"
+            },
+            "evidence": [
+              {
+                "identifiers": [
+                  {
+                    "id": "Apache-2.0",
+                    "name": "Apache License 2.0",
+                    "isDeprecated": false,
+                    "isOsiApproved": true,
+                    "isFsfLibre": true,
+                    "category": "PERMISSIVE"
+                  }
+                ],
+                "expression": "Apache-2.0",
+                "name": "Apache License 2.0",
+                "category": "PERMISSIVE",
+                "source": "deps.dev",
+                "sourceUrl": "https://api.deps.dev"
+              }
+            ]
+          },
+          "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5": {
+            "concluded": {
+              "identifiers": [
+                {
+                  "id": "GPL-2.0-only WITH Classpath-exception-2.0",
+                  "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
+                  "isDeprecated": false,
+                  "isOsiApproved": true,
+                  "isFsfLibre": true,
+                  "category": "WEAK_COPYLEFT"
+                }
+              ],
+              "expression": "GPL-2.0-only WITH Classpath-exception-2.0",
+              "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
+              "category": "WEAK_COPYLEFT",
+              "source": "deps.dev",
+              "sourceUrl": "https://api.deps.dev"
+            },
+            "evidence": [
+              {
+                "identifiers": [
+                  {
+                    "id": "non-standard",
+                    "name": "EPL 2.0",
+                    "category": "UNKNOWN"
+                  }
+                ],
+                "expression": "non-standard",
+                "name": "EPL 2.0",
+                "category": "UNKNOWN",
+                "source": "deps.dev",
+                "sourceUrl": "https://api.deps.dev"
+              },
+              {
+                "identifiers": [
+                  {
+                    "id": "GPL-2.0-only WITH Classpath-exception-2.0",
+                    "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
+                    "isDeprecated": false,
+                    "isOsiApproved": true,
+                    "isFsfLibre": true,
+                    "category": "WEAK_COPYLEFT"
+                  }
+                ],
+                "expression": "GPL-2.0-only WITH Classpath-exception-2.0",
+                "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
+                "category": "WEAK_COPYLEFT",
+                "source": "deps.dev",
+                "sourceUrl": "https://api.deps.dev"
+              }
+            ]
+          },
+          "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.1": {
+            "concluded": {
+              "identifiers": [
+                {
+                  "id": "Apache-2.0",
+                  "name": "Apache License 2.0",
+                  "isDeprecated": false,
+                  "isOsiApproved": true,
+                  "isFsfLibre": true,
+                  "category": "PERMISSIVE"
+                }
+              ],
+              "expression": "Apache-2.0",
+              "name": "Apache License 2.0",
+              "category": "PERMISSIVE",
+              "source": "deps.dev",
+              "sourceUrl": "https://api.deps.dev"
+            },
+            "evidence": [
+              {
+                "identifiers": [
+                  {
+                    "id": "Apache-2.0",
+                    "name": "Apache License 2.0",
+                    "isDeprecated": false,
+                    "isOsiApproved": true,
+                    "isFsfLibre": true,
+                    "category": "PERMISSIVE"
+                  }
+                ],
+                "expression": "Apache-2.0",
+                "name": "Apache License 2.0",
+                "category": "PERMISSIVE",
+                "source": "deps.dev",
+                "sourceUrl": "https://api.deps.dev"
+              }
+            ]
+          },
+          "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2": {
+            "concluded": {
+              "identifiers": [
+                {
+                  "id": "Apache-2.0",
+                  "name": "Apache License 2.0",
+                  "isDeprecated": false,
+                  "isOsiApproved": true,
+                  "isFsfLibre": true,
+                  "category": "PERMISSIVE"
+                }
+              ],
+              "expression": "Apache-2.0",
+              "name": "Apache License 2.0",
+              "category": "PERMISSIVE",
+              "source": "deps.dev",
+              "sourceUrl": "https://api.deps.dev"
+            },
+            "evidence": [
+              {
+                "identifiers": [
+                  {
+                    "id": "Apache-2.0",
+                    "name": "Apache License 2.0",
+                    "isDeprecated": false,
+                    "isOsiApproved": true,
+                    "isFsfLibre": true,
+                    "category": "PERMISSIVE"
+                  }
+                ],
+                "expression": "Apache-2.0",
+                "name": "Apache License 2.0",
+                "category": "PERMISSIVE",
+                "source": "deps.dev",
+                "sourceUrl": "https://api.deps.dev"
+              }
+            ]
+          },
+          "pkg:maven/jakarta.el/jakarta.el-api@3.0.3": {
+            "concluded": {
+              "identifiers": [
+                {
+                  "id": "GPL-2.0-only WITH Classpath-exception-2.0",
+                  "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
+                  "isDeprecated": false,
+                  "isOsiApproved": true,
+                  "isFsfLibre": true,
+                  "category": "WEAK_COPYLEFT"
+                }
+              ],
+              "expression": "GPL-2.0-only WITH Classpath-exception-2.0",
+              "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
+              "category": "WEAK_COPYLEFT",
+              "source": "deps.dev",
+              "sourceUrl": "https://api.deps.dev"
+            },
+            "evidence": [
+              {
+                "identifiers": [
+                  {
+                    "id": "non-standard",
+                    "name": "EPL 2.0",
+                    "category": "UNKNOWN"
+                  }
+                ],
+                "expression": "non-standard",
+                "name": "EPL 2.0",
+                "category": "UNKNOWN",
+                "source": "deps.dev",
+                "sourceUrl": "https://api.deps.dev"
+              },
+              {
+                "identifiers": [
+                  {
+                    "id": "GPL-2.0-only WITH Classpath-exception-2.0",
+                    "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
+                    "isDeprecated": false,
+                    "isOsiApproved": true,
+                    "isFsfLibre": true,
+                    "category": "WEAK_COPYLEFT"
+                  }
+                ],
+                "expression": "GPL-2.0-only WITH Classpath-exception-2.0",
+                "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
+                "category": "WEAK_COPYLEFT",
+                "source": "deps.dev",
+                "sourceUrl": "https://api.deps.dev"
+              }
+            ]
+          },
+          "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final": {
+            "concluded": {
+              "identifiers": [
+                {
+                  "id": "Apache-2.0",
+                  "name": "Apache License 2.0",
+                  "isDeprecated": false,
+                  "isOsiApproved": true,
+                  "isFsfLibre": true,
+                  "category": "PERMISSIVE"
+                }
+              ],
+              "expression": "Apache-2.0",
+              "name": "Apache License 2.0",
+              "category": "PERMISSIVE",
+              "source": "deps.dev",
+              "sourceUrl": "https://api.deps.dev"
+            },
+            "evidence": [
+              {
+                "identifiers": [
+                  {
+                    "id": "Apache-2.0",
+                    "name": "Apache License 2.0",
+                    "isDeprecated": false,
+                    "isOsiApproved": true,
+                    "isFsfLibre": true,
+                    "category": "PERMISSIVE"
+                  }
+                ],
+                "expression": "Apache-2.0",
+                "name": "Apache License 2.0",
+                "category": "PERMISSIVE",
+                "source": "deps.dev",
+                "sourceUrl": "https://api.deps.dev"
+              }
+            ]
+          },
+          "pkg:maven/org.postgresql/postgresql@42.5.0": {
+            "concluded": {
+              "identifiers": [
+                {
+                  "id": "BSD-2-Clause",
+                  "name": "BSD 2-Clause \"Simplified\" License",
+                  "isDeprecated": false,
+                  "isOsiApproved": true,
+                  "isFsfLibre": true,
+                  "category": "PERMISSIVE"
+                }
+              ],
+              "expression": "BSD-2-Clause",
+              "name": "BSD 2-Clause \"Simplified\" License",
+              "category": "PERMISSIVE",
+              "source": "deps.dev",
+              "sourceUrl": "https://api.deps.dev"
+            },
+            "evidence": [
+              {
+                "identifiers": [
+                  {
+                    "id": "BSD-2-Clause",
+                    "name": "BSD 2-Clause \"Simplified\" License",
+                    "isDeprecated": false,
+                    "isOsiApproved": true,
+                    "isFsfLibre": true,
+                    "category": "PERMISSIVE"
+                  }
+                ],
+                "expression": "BSD-2-Clause",
+                "name": "BSD 2-Clause \"Simplified\" License",
+                "category": "PERMISSIVE",
+                "source": "deps.dev",
+                "sourceUrl": "https://api.deps.dev"
+              }
+            ]
+          },
+          "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final": {
+            "concluded": {
+              "identifiers": [
+                {
+                  "id": "Apache-2.0",
+                  "name": "Apache License 2.0",
+                  "isDeprecated": false,
+                  "isOsiApproved": true,
+                  "isFsfLibre": true,
+                  "category": "PERMISSIVE"
+                }
+              ],
+              "expression": "Apache-2.0",
+              "name": "Apache License 2.0",
+              "category": "PERMISSIVE",
+              "source": "deps.dev",
+              "sourceUrl": "https://api.deps.dev"
+            },
+            "evidence": [
+              {
+                "identifiers": [
+                  {
+                    "id": "Apache-2.0",
+                    "name": "Apache License 2.0",
+                    "isDeprecated": false,
+                    "isOsiApproved": true,
+                    "isFsfLibre": true,
+                    "category": "PERMISSIVE"
+                  }
+                ],
+                "expression": "Apache-2.0",
+                "name": "Apache License 2.0",
+                "category": "PERMISSIVE",
+                "source": "deps.dev",
+                "sourceUrl": "https://api.deps.dev"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  },
+  "pkg:oci/debian@sha256:7c288032ecf3319045d9fa538c3b0cc868a320d01d03bce15b99c2c336319994?tag=0.0.1": {
+    "scanned": {
+      "total": 2,
+      "direct": 2,
+      "transitive": 0
+    },
+    "providers": {
+      "trustify": {
+        "status": {
+          "ok": true,
+          "name": "trustify",
+          "code": 200,
+          "message": "OK",
+          "warnings": {}
+        },
+        "sources": {},
+        "recommendations": {
+          "hardened-images": {
+            "summary": {
+              "total": 1
+            },
+            "dependencies": [
+              {
+                "ref": "pkg:oci/debian@sha256%3A7c288032ecf3319045d9fa538c3b0cc868a320d01d03bce15b99c2c336319994?tag=0.0.1",
+                "recommendation": "pkg:oci/ubi@sha256%3Af5983f7c7878cc9b26a3962be7756e3c810e9831b0b9f9613e6f6b445f884e74?arch=amd64&repository_url=registry.access.redhat.com%2Fubi9%2Fubi&tag=9.3-1552"
               }
             ]
           }
@@ -815,481 +1284,8 @@
           "message": "OK",
           "warnings": {}
         },
-        "sources": {}
-      }
-    },
-    "licenses": [
-      {
-        "status": {
-          "ok": true,
-          "name": "deps.dev",
-          "code": 200,
-          "message": "OK",
-          "warnings": {}
-        },
-        "summary": {
-          "total": 12,
-          "concluded": 10,
-          "permissive": 8,
-          "weakCopyleft": 2,
-          "strongCopyleft": 0,
-          "unknown": 2,
-          "deprecated": 0,
-          "osiApproved": 10,
-          "fsfLibre": 10
-        },
-        "packages": {
-          "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final": {
-            "concluded": {
-              "identifiers": [
-                {
-                  "id": "Apache-2.0",
-                  "name": "Apache License 2.0",
-                  "isDeprecated": false,
-                  "isOsiApproved": true,
-                  "isFsfLibre": true,
-                  "category": "PERMISSIVE"
-                }
-              ],
-              "expression": "Apache-2.0",
-              "name": "Apache License 2.0",
-              "category": "PERMISSIVE",
-              "source": "deps.dev",
-              "sourceUrl": "https://api.deps.dev"
-            },
-            "evidence": [
-              {
-                "identifiers": [
-                  {
-                    "id": "Apache-2.0",
-                    "name": "Apache License 2.0",
-                    "isDeprecated": false,
-                    "isOsiApproved": true,
-                    "isFsfLibre": true,
-                    "category": "PERMISSIVE"
-                  }
-                ],
-                "expression": "Apache-2.0",
-                "name": "Apache License 2.0",
-                "category": "PERMISSIVE",
-                "source": "deps.dev",
-                "sourceUrl": "https://api.deps.dev"
-              }
-            ]
-          },
-          "pkg:maven/io.quarkus/quarkus-jdbc-h2@2.13.5.Final": {
-            "concluded": {
-              "identifiers": [
-                {
-                  "id": "Apache-2.0",
-                  "name": "Apache License 2.0",
-                  "isDeprecated": false,
-                  "isOsiApproved": true,
-                  "isFsfLibre": true,
-                  "category": "PERMISSIVE"
-                }
-              ],
-              "expression": "Apache-2.0",
-              "name": "Apache License 2.0",
-              "category": "PERMISSIVE",
-              "source": "deps.dev",
-              "sourceUrl": "https://api.deps.dev"
-            },
-            "evidence": [
-              {
-                "identifiers": [
-                  {
-                    "id": "Apache-2.0",
-                    "name": "Apache License 2.0",
-                    "isDeprecated": false,
-                    "isOsiApproved": true,
-                    "isFsfLibre": true,
-                    "category": "PERMISSIVE"
-                  }
-                ],
-                "expression": "Apache-2.0",
-                "name": "Apache License 2.0",
-                "category": "PERMISSIVE",
-                "source": "deps.dev",
-                "sourceUrl": "https://api.deps.dev"
-              }
-            ]
-          },
-          "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final": {
-            "concluded": {
-              "identifiers": [
-                {
-                  "id": "Apache-2.0",
-                  "name": "Apache License 2.0",
-                  "isDeprecated": false,
-                  "isOsiApproved": true,
-                  "isFsfLibre": true,
-                  "category": "PERMISSIVE"
-                }
-              ],
-              "expression": "Apache-2.0",
-              "name": "Apache License 2.0",
-              "category": "PERMISSIVE",
-              "source": "deps.dev",
-              "sourceUrl": "https://api.deps.dev"
-            },
-            "evidence": [
-              {
-                "identifiers": [
-                  {
-                    "id": "Apache-2.0",
-                    "name": "Apache License 2.0",
-                    "isDeprecated": false,
-                    "isOsiApproved": true,
-                    "isFsfLibre": true,
-                    "category": "PERMISSIVE"
-                  }
-                ],
-                "expression": "Apache-2.0",
-                "name": "Apache License 2.0",
-                "category": "PERMISSIVE",
-                "source": "deps.dev",
-                "sourceUrl": "https://api.deps.dev"
-              }
-            ]
-          },
-          "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5": {
-            "concluded": {
-              "identifiers": [
-                {
-                  "id": "GPL-2.0-only WITH Classpath-exception-2.0",
-                  "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
-                  "isDeprecated": false,
-                  "isOsiApproved": true,
-                  "isFsfLibre": true,
-                  "category": "WEAK_COPYLEFT"
-                }
-              ],
-              "expression": "GPL-2.0-only WITH Classpath-exception-2.0",
-              "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
-              "category": "WEAK_COPYLEFT",
-              "source": "deps.dev",
-              "sourceUrl": "https://api.deps.dev"
-            },
-            "evidence": [
-              {
-                "identifiers": [
-                  {
-                    "id": "non-standard",
-                    "name": "EPL 2.0",
-                    "category": "UNKNOWN"
-                  }
-                ],
-                "expression": "non-standard",
-                "name": "EPL 2.0",
-                "category": "UNKNOWN",
-                "source": "deps.dev",
-                "sourceUrl": "https://api.deps.dev"
-              },
-              {
-                "identifiers": [
-                  {
-                    "id": "GPL-2.0-only WITH Classpath-exception-2.0",
-                    "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
-                    "isDeprecated": false,
-                    "isOsiApproved": true,
-                    "isFsfLibre": true,
-                    "category": "WEAK_COPYLEFT"
-                  }
-                ],
-                "expression": "GPL-2.0-only WITH Classpath-exception-2.0",
-                "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
-                "category": "WEAK_COPYLEFT",
-                "source": "deps.dev",
-                "sourceUrl": "https://api.deps.dev"
-              }
-            ]
-          },
-          "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.1": {
-            "concluded": {
-              "identifiers": [
-                {
-                  "id": "Apache-2.0",
-                  "name": "Apache License 2.0",
-                  "isDeprecated": false,
-                  "isOsiApproved": true,
-                  "isFsfLibre": true,
-                  "category": "PERMISSIVE"
-                }
-              ],
-              "expression": "Apache-2.0",
-              "name": "Apache License 2.0",
-              "category": "PERMISSIVE",
-              "source": "deps.dev",
-              "sourceUrl": "https://api.deps.dev"
-            },
-            "evidence": [
-              {
-                "identifiers": [
-                  {
-                    "id": "Apache-2.0",
-                    "name": "Apache License 2.0",
-                    "isDeprecated": false,
-                    "isOsiApproved": true,
-                    "isFsfLibre": true,
-                    "category": "PERMISSIVE"
-                  }
-                ],
-                "expression": "Apache-2.0",
-                "name": "Apache License 2.0",
-                "category": "PERMISSIVE",
-                "source": "deps.dev",
-                "sourceUrl": "https://api.deps.dev"
-              }
-            ]
-          },
-          "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2": {
-            "concluded": {
-              "identifiers": [
-                {
-                  "id": "Apache-2.0",
-                  "name": "Apache License 2.0",
-                  "isDeprecated": false,
-                  "isOsiApproved": true,
-                  "isFsfLibre": true,
-                  "category": "PERMISSIVE"
-                }
-              ],
-              "expression": "Apache-2.0",
-              "name": "Apache License 2.0",
-              "category": "PERMISSIVE",
-              "source": "deps.dev",
-              "sourceUrl": "https://api.deps.dev"
-            },
-            "evidence": [
-              {
-                "identifiers": [
-                  {
-                    "id": "Apache-2.0",
-                    "name": "Apache License 2.0",
-                    "isDeprecated": false,
-                    "isOsiApproved": true,
-                    "isFsfLibre": true,
-                    "category": "PERMISSIVE"
-                  }
-                ],
-                "expression": "Apache-2.0",
-                "name": "Apache License 2.0",
-                "category": "PERMISSIVE",
-                "source": "deps.dev",
-                "sourceUrl": "https://api.deps.dev"
-              }
-            ]
-          },
-          "pkg:maven/jakarta.el/jakarta.el-api@3.0.3": {
-            "concluded": {
-              "identifiers": [
-                {
-                  "id": "GPL-2.0-only WITH Classpath-exception-2.0",
-                  "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
-                  "isDeprecated": false,
-                  "isOsiApproved": true,
-                  "isFsfLibre": true,
-                  "category": "WEAK_COPYLEFT"
-                }
-              ],
-              "expression": "GPL-2.0-only WITH Classpath-exception-2.0",
-              "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
-              "category": "WEAK_COPYLEFT",
-              "source": "deps.dev",
-              "sourceUrl": "https://api.deps.dev"
-            },
-            "evidence": [
-              {
-                "identifiers": [
-                  {
-                    "id": "non-standard",
-                    "name": "EPL 2.0",
-                    "category": "UNKNOWN"
-                  }
-                ],
-                "expression": "non-standard",
-                "name": "EPL 2.0",
-                "category": "UNKNOWN",
-                "source": "deps.dev",
-                "sourceUrl": "https://api.deps.dev"
-              },
-              {
-                "identifiers": [
-                  {
-                    "id": "GPL-2.0-only WITH Classpath-exception-2.0",
-                    "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
-                    "isDeprecated": false,
-                    "isOsiApproved": true,
-                    "isFsfLibre": true,
-                    "category": "WEAK_COPYLEFT"
-                  }
-                ],
-                "expression": "GPL-2.0-only WITH Classpath-exception-2.0",
-                "name": "GNU General Public License v2.0 only with Classpath exception 2.0",
-                "category": "WEAK_COPYLEFT",
-                "source": "deps.dev",
-                "sourceUrl": "https://api.deps.dev"
-              }
-            ]
-          },
-          "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final": {
-            "concluded": {
-              "identifiers": [
-                {
-                  "id": "Apache-2.0",
-                  "name": "Apache License 2.0",
-                  "isDeprecated": false,
-                  "isOsiApproved": true,
-                  "isFsfLibre": true,
-                  "category": "PERMISSIVE"
-                }
-              ],
-              "expression": "Apache-2.0",
-              "name": "Apache License 2.0",
-              "category": "PERMISSIVE",
-              "source": "deps.dev",
-              "sourceUrl": "https://api.deps.dev"
-            },
-            "evidence": [
-              {
-                "identifiers": [
-                  {
-                    "id": "Apache-2.0",
-                    "name": "Apache License 2.0",
-                    "isDeprecated": false,
-                    "isOsiApproved": true,
-                    "isFsfLibre": true,
-                    "category": "PERMISSIVE"
-                  }
-                ],
-                "expression": "Apache-2.0",
-                "name": "Apache License 2.0",
-                "category": "PERMISSIVE",
-                "source": "deps.dev",
-                "sourceUrl": "https://api.deps.dev"
-              }
-            ]
-          },
-          "pkg:maven/org.postgresql/postgresql@42.5.0": {
-            "concluded": {
-              "identifiers": [
-                {
-                  "id": "BSD-2-Clause",
-                  "name": "BSD 2-Clause \"Simplified\" License",
-                  "isDeprecated": false,
-                  "isOsiApproved": true,
-                  "isFsfLibre": true,
-                  "category": "PERMISSIVE"
-                }
-              ],
-              "expression": "BSD-2-Clause",
-              "name": "BSD 2-Clause \"Simplified\" License",
-              "category": "PERMISSIVE",
-              "source": "deps.dev",
-              "sourceUrl": "https://api.deps.dev"
-            },
-            "evidence": [
-              {
-                "identifiers": [
-                  {
-                    "id": "BSD-2-Clause",
-                    "name": "BSD 2-Clause \"Simplified\" License",
-                    "isDeprecated": false,
-                    "isOsiApproved": true,
-                    "isFsfLibre": true,
-                    "category": "PERMISSIVE"
-                  }
-                ],
-                "expression": "BSD-2-Clause",
-                "name": "BSD 2-Clause \"Simplified\" License",
-                "category": "PERMISSIVE",
-                "source": "deps.dev",
-                "sourceUrl": "https://api.deps.dev"
-              }
-            ]
-          },
-          "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final": {
-            "concluded": {
-              "identifiers": [
-                {
-                  "id": "Apache-2.0",
-                  "name": "Apache License 2.0",
-                  "isDeprecated": false,
-                  "isOsiApproved": true,
-                  "isFsfLibre": true,
-                  "category": "PERMISSIVE"
-                }
-              ],
-              "expression": "Apache-2.0",
-              "name": "Apache License 2.0",
-              "category": "PERMISSIVE",
-              "source": "deps.dev",
-              "sourceUrl": "https://api.deps.dev"
-            },
-            "evidence": [
-              {
-                "identifiers": [
-                  {
-                    "id": "Apache-2.0",
-                    "name": "Apache License 2.0",
-                    "isDeprecated": false,
-                    "isOsiApproved": true,
-                    "isFsfLibre": true,
-                    "category": "PERMISSIVE"
-                  }
-                ],
-                "expression": "Apache-2.0",
-                "name": "Apache License 2.0",
-                "category": "PERMISSIVE",
-                "source": "deps.dev",
-                "sourceUrl": "https://api.deps.dev"
-              }
-            ]
-          }
-        }
-      }
-    ]
-  },
-  "pkg:oci/debian@sha256:7c288032ecf3319045d9fa538c3b0cc868a320d01d03bce15b99c2c336319994?tag=0.0.1": {
-    "scanned": {
-      "total": 2,
-      "direct": 2,
-      "transitive": 0
-    },
-    "providers": {
-      "trustify": {
-        "status": {
-          "ok": true,
-          "name": "trustify",
-          "code": 200,
-          "message": "OK",
-          "warnings": {}
-        },
-        "sources": {
-          "trustify": {
-            "summary": {
-              "direct": 0,
-              "transitive": 0,
-              "total": 0,
-              "dependencies": 0,
-              "critical": 0,
-              "high": 0,
-              "medium": 0,
-              "low": 0,
-              "remediations": 0,
-              "recommendations": 1,
-              "unscanned": 0
-            },
-            "dependencies": [
-              {
-                "ref": "pkg:oci/debian@sha256%3A7c288032ecf3319045d9fa538c3b0cc868a320d01d03bce15b99c2c336319994?tag=0.0.1",
-                "transitive": [],
-                "recommendation": "pkg:oci/ubi@sha256%3Af5983f7c7878cc9b26a3962be7756e3c810e9831b0b9f9613e6f6b445f884e74?arch=amd64&repository_url=registry.access.redhat.com%2Fubi9%2Fubi&tag=9.3-1552"
-              }
-            ]
-          }
-        }
+        "sources": {},
+        "recommendations": {}
       }
     },
     "licenses": [

--- a/src/test/resources/__files/reports/pypi_report.json
+++ b/src/test/resources/__files/reports/pypi_report.json
@@ -78,6 +78,23 @@
                         }
                     ]
                 }
+            },
+            "recommendations": {
+                "trusted-libraries": {
+                    "summary": {
+                        "total": 2
+                    },
+                    "dependencies": [
+                        {
+                            "ref": "pkg:pypi/requests@2.31.0",
+                            "recommendation": "pkg:pypi/requests@2.31.0?repository_url=https%3A%2F%2Fpackages.redhat.com%2Ftrusted-libraries%2Fpython"
+                        },
+                        {
+                            "ref": "pkg:pypi/flask@3.0.0",
+                            "recommendation": "pkg:pypi/flask@3.0.0?repository_url=https%3A%2F%2Fpackages.redhat.com%2Ftrusted-libraries%2Fpython"
+                        }
+                    ]
+                }
             }
         }
     },

--- a/src/test/resources/__files/reports/report.json
+++ b/src/test/resources/__files/reports/report.json
@@ -29,7 +29,7 @@
             "medium": 2,
             "low": 0,
             "remediations": 2,
-            "recommendations": 6,
+            "recommendations": 0,
             "unscanned": 0
           },
           "dependencies": [
@@ -75,7 +75,6 @@
                   }
                 }
               ],
-              "recommendation": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar",
               "highestVulnerability": {
                 "id": "CVE-2024-1597",
                 "title": "pgjdbc SQL Injection via line comment generation",
@@ -200,7 +199,6 @@
                   }
                 }
               ],
-              "recommendation": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar",
               "highestVulnerability": {
                 "id": "CVE-2020-36518",
                 "title": "jackson-databind before 2.13.0 allows a Java StackOverflow exception and denial of service via a large depth of nested objects.",
@@ -219,22 +217,6 @@
                   }
                 }
               }
-            },
-            {
-              "ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
-              "recommendation": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3.redhat-00002?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
-            },
-            {
-              "ref": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2?type=jar",
-              "recommendation": "pkg:maven/jakarta.enterprise/jakarta.enterprise.cdi-api@2.0.2.redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
-            },
-            {
-              "ref": "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final?type=jar",
-              "recommendation": "pkg:maven/io.quarkus/quarkus-narayana-jta@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
-            },
-            {
-              "ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar",
-              "recommendation": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5.redhat-00003?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
             }
           ]
         },
@@ -249,7 +231,7 @@
             "medium": 0,
             "low": 0,
             "remediations": 0,
-            "recommendations": 7,
+            "recommendations": 0,
             "unscanned": 0
           },
           "dependencies": [
@@ -284,7 +266,6 @@
                   }
                 }
               ],
-              "recommendation": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar",
               "highestVulnerability": {
                 "id": "CVE-2024-1597",
                 "title": "pgjdbc SQL Injection via line comment generation",
@@ -328,7 +309,6 @@
                   }
                 }
               ],
-              "recommendation": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar",
               "highestVulnerability": {
                 "id": "CVE-2024-2700",
                 "title": "Quarkus-core: leak of local configuration properties into quarkus applications",
@@ -340,6 +320,23 @@
                 ],
                 "unique": false
               }
+            }
+          ]
+        }
+      },
+      "recommendations": {
+        "trusted-content": {
+          "summary": {
+            "total": 9
+          },
+          "dependencies": [
+            {
+              "ref": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final?type=jar",
+              "recommendation": "pkg:maven/io.quarkus/quarkus-jdbc-postgresql@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
+            },
+            {
+              "ref": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final?type=jar",
+              "recommendation": "pkg:maven/io.quarkus/quarkus-hibernate-orm@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
             },
             {
               "ref": "pkg:maven/jakarta.el/jakarta.el-api@3.0.3?type=jar",
@@ -360,6 +357,14 @@
             {
               "ref": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5?type=jar",
               "recommendation": "pkg:maven/jakarta.interceptor/jakarta.interceptor-api@1.2.5.redhat-00003?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
+            },
+            {
+              "ref": "pkg:maven/org.postgresql/postgresql@42.5.0?type=jar",
+              "recommendation": "pkg:maven/org.postgresql/postgresql@42.5.0.redhat-00001?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
+            },
+            {
+              "ref": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final?type=jar",
+              "recommendation": "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final-redhat-00004?repository_url=https%3A%2F%2Fmaven.repository.redhat.com%2Fga%2F&type=jar"
             }
           ]
         }


### PR DESCRIPTION
## Summary
- Move recommendations out of per-dependency vulnerability sources into a dedicated provider-level `recommendations` map, keyed by source name (`trusted-content`, `hardened-images`, `trusted-libraries`)
- Eliminates recommendation duplication across multiple vulnerability sources and removes fake source entries for recommendation-only packages
- Tracks recommendation origin (`sourceName`) through the full pipeline: `IndexedRecommendation` → `Recommendation` → `PackageItem` → `ProviderReport`

## Test plan
- [x] Unit tests for recommendations map with no issues
- [x] Unit tests for no duplication across sources
- [x] Unit tests for backward-compat `DependencyReport.recommendation`
- [x] Unit tests for multiple recommendation sources
- [x] Unit tests for null source name exclusion
- [x] Unit tests for source name preservation through aggregation
- [x] Unit tests for registry enrichment populating recommendations map

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Surface dependency recommendations via a provider-level map grouped by source while preserving backward compatibility with per-source dependency reports.

New Features:
- Introduce provider-level recommendations map on ProviderReport, keyed by recommendation source names such as trusted-content, hardened-images, and trusted-libraries.
- Propagate recommendation source metadata through aggregation models (IndexedRecommendation, Recommendation, PackageItem) into provider reports and registry enrichment.

Enhancements:
- Refine grouping of PackageItems by vulnerability source to exclude recommendation-only entries from vulnerability sources and rely on the new recommendations map.
- Update registry enrichment to populate the provider-level recommendations map for both reported and unreported dependencies and keep deprecated per-dependency recommendations in sync.

Build:
- Bump trustify-da-api dependency version to 2.0.8-SNAPSHOT.

Tests:
- Add unit tests covering recommendation-only packages, non-duplication across sources, backward compatibility of DependencyReport.recommendation, multiple recommendation sources, null source exclusion, and propagation through aggregation and enrichment.