### PR TITLE
revert: skip CVEs without CVSS scores for release

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandler.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandler.java
@@ -141,7 +141,9 @@ public class TrustifyResponseHandler extends ProviderResponseHandler {
                 }
                 var issue = new Issue().id(id).title(iTitle).source(source).cves(List.of(id));
                 setCvssData(issue, data);
-                issuesByCveSource.put(key, issue);
+                if (issue.getCvssScore() != null) {
+                  issuesByCveSource.put(key, issue);
+                }
               });
           issues.addAll(issuesByCveSource.values());
         });

--- a/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandlerTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyResponseHandlerTest.java
@@ -21,7 +21,6 @@ import static io.github.guacsec.trustifyda.integration.providers.ProviderRespons
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.mock;
@@ -648,9 +647,6 @@ public class TrustifyResponseHandlerTest {
     assertTrue(issues.isEmpty());
   }
 
-  /**
-   * Verifies that a vulnerability with no scores is reported with null severity and null cvssScore.
-   */
   @Test
   void testResponseToIssuesWithNoScores() throws IOException {
     String jsonResponse =
@@ -690,22 +686,11 @@ public class TrustifyResponseHandlerTest {
     ProviderResponse result =
         handler.responseToIssues(buildExchange(responseBytes, dependencyTree));
 
-    // Given a vulnerability with no scores array
     assertNotNull(result);
     PackageItem packageItem = result.pkgItems().get("pkg:maven/org.postgresql/postgresql@42.5.0");
     assertNotNull(packageItem);
     List<Issue> issues = packageItem.issues();
-
-    // Then the vulnerability is still reported with null severity and null cvssScore
-    assertEquals(1, issues.size());
-    Issue issue = issues.get(0);
-    assertEquals("CVE-2024-1597", issue.getId());
-    assertNull(issue.getCvssScore(), "cvssScore should be null when no scores are available");
-    assertNull(issue.getSeverity(), "severity should be null when no scores are available");
-
-    // Then remediation data is still populated
-    assertNotNull(issue.getRemediation());
-    assertEquals(List.of("42.5.5"), issue.getRemediation().getFixedIn());
+    assertTrue(issues.isEmpty());
   }
 
   @Test
@@ -1201,8 +1186,8 @@ public class TrustifyResponseHandlerTest {
   }
 
   /**
-   * Verifies that vulnerabilities with only invalid severity scores (e.g., "none") are reported
-   * with null severity, and that valid scores in mixed-score advisories are used correctly.
+   * Verifies that vulnerabilities with only invalid severity scores (e.g., "none") are skipped, and
+   * that valid scores in mixed-score advisories are used correctly.
    */
   @Test
   void testResponseToIssuesWithInvalidSeverity() throws IOException {
@@ -1289,17 +1274,10 @@ public class TrustifyResponseHandlerTest {
     assertNotNull(result.pkgItems());
     assertEquals(2, result.pkgItems().size());
 
-    // Package with only invalid severity should be reported with null severity
     PackageItem packageItem1 = result.pkgItems().get("pkg:maven/org.postgresql/postgresql@42.5.0");
-    assertNotNull(packageItem1);
+    assertNotNull(packageItem1, "Package with no valid scores should be present");
     List<Issue> issues = packageItem1.issues();
-    assertEquals(1, issues.size(), "Vulnerability with invalid severity should still be reported");
-    assertNull(
-        issues.get(0).getCvssScore(),
-        "cvssScore should be null when all scores have invalid severity");
-    assertNull(
-        issues.get(0).getSeverity(),
-        "severity should be null when all scores have invalid severity");
+    assertTrue(issues.isEmpty(), "Package with no valid scores should have no issues");
 
     // Package with mixed valid/invalid scores should use the valid score
     PackageItem packageItem2 = result.pkgItems().get("pkg:maven/com.other/package@2.0.0");
@@ -1312,7 +1290,6 @@ public class TrustifyResponseHandlerTest {
         Severity.HIGH, issues.get(0).getSeverity(), "Issue should have the correct severity");
   }
 
-  /** Verifies that a vulnerability with an empty scores array is reported with null severity. */
   @Test
   void testResponseToIssuesWithEmptyScoresArray() throws IOException {
     String jsonResponse =
@@ -1353,21 +1330,10 @@ public class TrustifyResponseHandlerTest {
     ProviderResponse result =
         handler.responseToIssues(buildExchange(responseBytes, dependencyTree));
 
-    // Given a vulnerability with an empty scores array
     assertNotNull(result);
     PackageItem packageItem = result.pkgItems().get("pkg:maven/org.postgresql/postgresql@42.5.0");
     assertNotNull(packageItem);
     List<Issue> issues = packageItem.issues();
-
-    // Then the vulnerability is reported with null severity and null cvssScore
-    assertEquals(1, issues.size());
-    Issue issue = issues.get(0);
-    assertEquals("CVE-2025-24898", issue.getId());
-    assertNull(issue.getCvssScore(), "cvssScore should be null when scores array is empty");
-    assertNull(issue.getSeverity(), "severity should be null when scores array is empty");
-
-    // Then remediation data is still populated
-    assertNotNull(issue.getRemediation());
-    assertEquals(List.of("0.10.70"), issue.getRemediation().getFixedIn());
+    assertTrue(issues.isEmpty());
   }
 }


### PR DESCRIPTION
## Summary

- Restore the null-score guard in `TrustifyResponseHandler` that was removed in PR #613 (TC-4548)
- CVEs without CVSS scores (e.g., RUSTSEC advisories) are temporarily skipped for this release
- All null-safe comparator safeguards in `ProviderResponseHandler` and `CvssScoreComparable` are kept intact for the post-release un-revert (TC-4743)

Implements [TC-4742](https://redhat.atlassian.net/browse/TC-4742)

## Test plan

- [x] Vulnerability with no scores array → filtered out (empty issues)
- [x] Vulnerability with empty scores array → filtered out (empty issues)
- [x] Vulnerability with only invalid severity (e.g., "none") → filtered out
- [x] Vulnerability with valid scores → reported with correct severity (unchanged)
- [x] Full test suite passes (274/274)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4742]: https://redhat.atlassian.net/browse/TC-4742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Reinstate filtering of vulnerabilities without valid CVSS scores so that only issues with non-null scores are reported, and update tests to expect CVE entries with missing, empty, or invalid scores to be skipped.

Bug Fixes:
- Skip vulnerabilities with no scores, empty score arrays, or only invalid severity scores instead of emitting issues with null severity or CVSS.

Tests:
- Adjust Trustify response handler integration tests to assert that packages with no valid scores produce no issues while preserving behavior for mixed valid/invalid scores.