### PR TITLE
feat(licenses): instrument deps.dev routes with ProviderRoutePolicy

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -158,6 +158,39 @@ Use this pattern when the helper has no injected dependencies and serves as a pu
 - **Dynamic URLs**: Use `.toD("${exchangeProperty.propertyName}?throwExceptionOnFailure=false")` for URLs resolved at runtime from exchange properties.
 - **Single entry point**: The main analysis route (`ExhortIntegration`) calls `direct:enrichTrustedLibraries` as a single entry point. The orchestrator (`TrustedLibrariesIntegration`) discovers and runs all registry integrations. Never add ecosystem-specific routes directly to the main analysis route.
 
+## Telemetry and Metrics
+
+Every Camel route that makes external HTTP requests must be instrumented with `ProviderRoutePolicy` so it appears in the Grafana provider dashboards. This applies to vulnerability providers, license providers, registry integrations, and any future integration that calls an external service.
+
+### How to instrument a route
+
+1. **Inject `MeterRegistry`** into the route builder class:
+   ```java
+   @Inject MeterRegistry registry;
+   ```
+2. **Attach `ProviderRoutePolicy`** immediately after `.routeId(...)`:
+   ```java
+   .routePolicy(new ProviderRoutePolicy(registry))
+   ```
+3. **Set the provider name** on the exchange before the circuit breaker:
+   ```java
+   .setProperty(Constants.PROVIDER_NAME_PROPERTY, constant("provider-name"))
+   ```
+
+This produces a `camel.route.provider.requests` timer with `provider` and `routeId` tags, p90/p95/p99 percentiles, and SLO histogram buckets.
+
+### Currently instrumented routes
+
+| Integration | Route ID | Provider tag | Status |
+|---|---|---|---|
+| TrustifyIntegration | `trustifyRequest`, `trustifyToken`, `trustifyPurls`, `trustifyLookup` | `trustify` | Instrumented |
+| LicensesIntegration | `depsDevRequest` | `deps.dev` | Instrumented |
+| Pep691Integration | `pep691Lookup` | `pypi` | Instrumented |
+
+### Routes pending instrumentation
+
+- **Hardened images integration** (not yet implemented) — should include `ProviderRoutePolicy` from the start
+
 ## Testing Conventions
 
 - **Frameworks**: JUnit 5 (Jupiter), Quarkus Test, Mockito (via `quarkus-junit5-mockito`)

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -183,7 +183,7 @@ This produces a `camel.route.provider.requests` timer with `provider` and `route
 
 | Integration | Route ID | Provider tag | Status |
 |---|---|---|---|
-| TrustifyIntegration | `trustifyRequest`, `trustifyToken`, `trustifyPurls`, `trustifyLookup` | `trustify` | Instrumented |
+| TrustifyIntegration | `recommendations`, `vulnerabilities`, `trustifyHealthCheck`, `trustifyValidateCredentials` | `trustify` | Instrumented |
 | LicensesIntegration | `depsDevRequest` | `deps.dev` | Instrumented |
 | Pep691Integration | `pep691Lookup` | `pypi` | Instrumented |
 

--- a/src/main/java/io/github/guacsec/trustifyda/integration/licenses/LicensesIntegration.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/licenses/LicensesIntegration.java
@@ -42,8 +42,10 @@ import io.github.guacsec.trustifyda.api.v5.PackageLicenseResult;
 import io.github.guacsec.trustifyda.api.v5.ProviderStatus;
 import io.github.guacsec.trustifyda.integration.Constants;
 import io.github.guacsec.trustifyda.integration.cache.CacheService;
+import io.github.guacsec.trustifyda.integration.providers.trustify.ProviderRoutePolicy;
 import io.github.guacsec.trustifyda.model.licenses.LicenseSplitResult;
 import io.github.guacsec.trustifyda.monitoring.MonitoringProcessor;
+import io.micrometer.core.instrument.MeterRegistry;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -79,6 +81,7 @@ public class LicensesIntegration extends EndpointRouteBuilder {
   @Inject SpdxLicenseService spdxLicenseService;
   @Inject CacheService cacheService;
   @Inject MonitoringProcessor monitoringProcessor;
+  @Inject MeterRegistry registry;
 
   @Override
   public void configure() {
@@ -172,6 +175,8 @@ public class LicensesIntegration extends EndpointRouteBuilder {
 
     from(direct("depsDevRequest"))
       .routeId("depsDevRequest")
+      .routePolicy(new ProviderRoutePolicy(registry))
+      .setProperty(Constants.PROVIDER_NAME_PROPERTY, constant(DEPS_DEV_SOURCE))
       .circuitBreaker()
       .faultToleranceConfiguration()
         .timeoutEnabled(true)

--- a/src/main/java/io/github/guacsec/trustifyda/integration/registry/Pep691Integration.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/registry/Pep691Integration.java
@@ -33,8 +33,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.guacsec.trustifyda.api.PackageRef;
 import io.github.guacsec.trustifyda.api.v5.AnalysisReport;
 import io.github.guacsec.trustifyda.integration.Constants;
+import io.github.guacsec.trustifyda.integration.providers.trustify.ProviderRoutePolicy;
 import io.github.guacsec.trustifyda.model.DependencyTree;
 import io.github.guacsec.trustifyda.model.registry.Pep691Response;
+import io.micrometer.core.instrument.MeterRegistry;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -49,6 +51,7 @@ public class Pep691Integration extends EndpointRouteBuilder implements RegistryI
   private static final String PKG_PYPI_PREFIX = "pkg:pypi/";
   private static final String PEP691_URL_PROPERTY = "pep691RegistryUrl";
   private static final String PEP691_PACKAGE_PROPERTY = "pep691PackageName";
+  private static final String PYPI_SOURCE = "pypi";
 
   @ConfigProperty(name = "api.pypi.registry.host")
   Optional<String> registryHost;
@@ -61,6 +64,8 @@ public class Pep691Integration extends EndpointRouteBuilder implements RegistryI
   @Inject ObjectMapper objectMapper;
 
   @Inject ProducerTemplate producerTemplate;
+
+  @Inject MeterRegistry registry;
 
   @Override
   public boolean isEnabled() {
@@ -77,6 +82,8 @@ public class Pep691Integration extends EndpointRouteBuilder implements RegistryI
     // fmt:off
     from(direct("pep691Lookup"))
       .routeId("pep691Lookup")
+      .routePolicy(new ProviderRoutePolicy(registry))
+      .setProperty(Constants.PROVIDER_NAME_PROPERTY, constant(PYPI_SOURCE))
       .circuitBreaker()
         .faultToleranceConfiguration()
           .timeoutEnabled(true)


### PR DESCRIPTION
## Summary

- Inject `MeterRegistry` into `LicensesIntegration` and attach `ProviderRoutePolicy` to the `depsDevRequest` route
- Set `Constants.PROVIDER_NAME_PROPERTY` to `"deps.dev"` on exchanges so the metric is tagged correctly
- Follows the exact same pattern already used in `TrustifyIntegration` for vulnerability provider routes

Implements [TC-4758](https://redhat.atlassian.net/browse/TC-4758)

## Test plan

- [x] All 274 existing tests pass (`mvn verify`)
- [x] `mvn spotless:apply` exits cleanly
- [ ] After a deps.dev license lookup, verify `/q/metrics` exposes `camel_route_provider_requests_seconds_count{provider="deps.dev",routeId="depsDevRequest"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4758]: https://redhat.atlassian.net/browse/TC-4758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Instrument the deps.dev license provider route with provider-aware metrics.

Enhancements:
- Inject the application metrics registry into LicensesIntegration and apply ProviderRoutePolicy to the deps.dev request route so its traffic is recorded.
- Tag deps.dev license requests with the appropriate provider name property to align with existing provider metrics.