### PR TITLE
fix(licenses): reduce batch size to match deps.dev API response cap

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/integration/licenses/DepsDevRequestBuilder.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/licenses/DepsDevRequestBuilder.java
@@ -38,6 +38,10 @@ public class DepsDevRequestBuilder {
 
   private static final int BATCH_SIZE = 100;
 
+  public static String cacheKey(PackageRef ref) {
+    return ref.purl().getCoordinates();
+  }
+
   public boolean isEmpty(List<PackageRef> purls) {
     return purls == null || purls.isEmpty();
   }
@@ -49,7 +53,7 @@ public class DepsDevRequestBuilder {
     var depsDevReq = MAPPER.createObjectNode();
     var requests = MAPPER.createArrayNode();
     for (var p : purls) {
-      requests.add(MAPPER.createObjectNode().put("purl", p.purl().getCoordinates()));
+      requests.add(MAPPER.createObjectNode().put("purl", cacheKey(p)));
     }
     depsDevReq.set("requests", requests);
     return depsDevReq;

--- a/src/main/java/io/github/guacsec/trustifyda/integration/licenses/DepsDevRequestBuilder.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/licenses/DepsDevRequestBuilder.java
@@ -36,7 +36,7 @@ public class DepsDevRequestBuilder {
 
   private static final ObjectMapper MAPPER = ObjectMapperProducer.newInstance();
 
-  private static final int BATCH_SIZE = 500;
+  private static final int BATCH_SIZE = 100;
 
   public boolean isEmpty(List<PackageRef> purls) {
     return purls == null || purls.isEmpty();

--- a/src/main/java/io/github/guacsec/trustifyda/integration/licenses/DepsDevResponseHandler.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/licenses/DepsDevResponseHandler.java
@@ -60,6 +60,10 @@ public class DepsDevResponseHandler {
 
   public void handleResponse(Exchange exchange) {
     try {
+      var statusCode = exchange.getIn().getHeader(Exchange.HTTP_RESPONSE_CODE, Integer.class);
+      if (statusCode != null && statusCode >= 300) {
+        LOGGER.infof("Deps.dev licenses API returned HTTP %d", statusCode);
+      }
       var body = exchange.getIn().getBody(String.class);
       if (body == null || body.isBlank()) {
         throw new RuntimeException("Empty response from Deps.dev licenses API");
@@ -71,37 +75,39 @@ public class DepsDevResponseHandler {
         throw new RuntimeException("Invalid response format: missing or non-array 'responses'");
       }
       var responses = (ArrayNode) json.get("responses");
-      responses.forEach(
-          response -> {
-            var infos = new ArrayList<LicenseInfo>();
-            var request = (ObjectNode) response.get("request");
-            var purl = request.get("purl").asText();
-            if (response.has("result")) {
-              var result = (ObjectNode) response.get("result");
-              if (result.has("version")) {
-                var version = result.get("version");
-                var licensesNode = (ArrayNode) version.get("licenseDetails");
-                licensesNode.forEach(
-                    licenseNode -> {
-                      var spdx = licenseNode.get("spdx").asText();
-                      var licenseField = licenseNode.get("license");
-                      var license =
-                          licenseField != null && !licenseField.isNull()
-                              ? licenseField.asText()
-                              : null;
-                      var info =
-                          spdxLicenseService.fromLicenseId(
-                              spdx, DEPS_DEV_SOURCE, depsDevHost, license);
-                      infos.add(info);
-                    });
-              }
-            }
-            var packageResult =
-                new PackageLicenseResult()
-                    .concluded(spdxLicenseService.getConcluded(infos))
-                    .evidence(infos);
-            results.put(purl, packageResult);
-          });
+      int noResult = 0;
+      for (var response : responses) {
+        var infos = new ArrayList<LicenseInfo>();
+        var request = (ObjectNode) response.get("request");
+        var purl = request.get("purl").asText();
+        if (response.has("result")) {
+          var result = (ObjectNode) response.get("result");
+          if (result.has("version")) {
+            var version = result.get("version");
+            var licensesNode = (ArrayNode) version.get("licenseDetails");
+            licensesNode.forEach(
+                licenseNode -> {
+                  var spdx = licenseNode.get("spdx").asText();
+                  var licenseField = licenseNode.get("license");
+                  var license =
+                      licenseField != null && !licenseField.isNull() ? licenseField.asText() : null;
+                  var info =
+                      spdxLicenseService.fromLicenseId(spdx, DEPS_DEV_SOURCE, depsDevHost, license);
+                  infos.add(info);
+                });
+          }
+        } else {
+          noResult++;
+        }
+        var packageResult =
+            new PackageLicenseResult()
+                .concluded(spdxLicenseService.getConcluded(infos))
+                .evidence(infos);
+        results.put(purl, packageResult);
+      }
+      LOGGER.debugf(
+          "Deps.dev batch: %d responses, %d with license data, %d without",
+          responses.size(), responses.size() - noResult, noResult);
       exchange
           .getMessage()
           .setBody(

--- a/src/main/java/io/github/guacsec/trustifyda/integration/licenses/DepsDevResponseHandler.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/licenses/DepsDevResponseHandler.java
@@ -75,6 +75,8 @@ public class DepsDevResponseHandler {
         throw new RuntimeException("Invalid response format: missing or non-array 'responses'");
       }
       var responses = (ArrayNode) json.get("responses");
+      int withLicenses = 0;
+      int withoutLicenses = 0;
       int noResult = 0;
       for (var response : responses) {
         var infos = new ArrayList<LicenseInfo>();
@@ -84,17 +86,28 @@ public class DepsDevResponseHandler {
           var result = (ObjectNode) response.get("result");
           if (result.has("version")) {
             var version = result.get("version");
-            var licensesNode = (ArrayNode) version.get("licenseDetails");
-            licensesNode.forEach(
-                licenseNode -> {
-                  var spdx = licenseNode.get("spdx").asText();
-                  var licenseField = licenseNode.get("license");
-                  var license =
-                      licenseField != null && !licenseField.isNull() ? licenseField.asText() : null;
-                  var info =
-                      spdxLicenseService.fromLicenseId(spdx, DEPS_DEV_SOURCE, depsDevHost, license);
-                  infos.add(info);
-                });
+            var licenseDetailsNode = version.get("licenseDetails");
+            if (licenseDetailsNode != null && licenseDetailsNode.isArray()) {
+              var licensesNode = (ArrayNode) licenseDetailsNode;
+              licensesNode.forEach(
+                  licenseNode -> {
+                    var spdx = licenseNode.get("spdx").asText();
+                    var licenseField = licenseNode.get("license");
+                    var license =
+                        licenseField != null && !licenseField.isNull()
+                            ? licenseField.asText()
+                            : null;
+                    var info =
+                        spdxLicenseService.fromLicenseId(
+                            spdx, DEPS_DEV_SOURCE, depsDevHost, license);
+                    infos.add(info);
+                  });
+            }
+          }
+          if (infos.isEmpty()) {
+            withoutLicenses++;
+          } else {
+            withLicenses++;
           }
         } else {
           noResult++;
@@ -106,8 +119,8 @@ public class DepsDevResponseHandler {
         results.put(purl, packageResult);
       }
       LOGGER.debugf(
-          "Deps.dev batch: %d responses, %d with license data, %d without",
-          responses.size(), responses.size() - noResult, noResult);
+          "Deps.dev batch: %d responses, %d with licenses, %d without licenses, %d no result",
+          responses.size(), withLicenses, withoutLicenses, noResult);
       exchange
           .getMessage()
           .setBody(

--- a/src/main/java/io/github/guacsec/trustifyda/integration/licenses/LicensesIntegration.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/licenses/LicensesIntegration.java
@@ -233,7 +233,7 @@ public class LicensesIntegration extends EndpointRouteBuilder {
       cacheHits = Collections.emptyMap();
     }
     Map<String, PackageLicenseResult> packages = new HashMap<>();
-    cacheHits.forEach((ref, result) -> packages.put(ref.ref(), result));
+    cacheHits.forEach((ref, result) -> packages.put(ref.purl().getCoordinates(), result));
     var status = new ProviderStatus().ok(true).name(DEPS_DEV_SOURCE);
     exchange.getIn().setBody(new LicenseSplitResult(status, packages));
   }
@@ -248,7 +248,7 @@ public class LicensesIntegration extends EndpointRouteBuilder {
     LicenseSplitResult result = exchange.getIn().getBody(LicenseSplitResult.class);
     if (result == null) {
       Map<String, PackageLicenseResult> packages = new HashMap<>();
-      cacheHits.forEach((ref, r) -> packages.put(ref.ref(), r));
+      cacheHits.forEach((ref, r) -> packages.put(ref.purl().getCoordinates(), r));
       exchange
           .getIn()
           .setBody(
@@ -257,7 +257,10 @@ public class LicensesIntegration extends EndpointRouteBuilder {
       return;
     }
     Map<String, PackageLicenseResult> merged = new HashMap<>(result.packages());
-    cacheHits.forEach((ref, r) -> merged.put(ref.ref(), r));
+    cacheHits.forEach((ref, r) -> merged.put(ref.purl().getCoordinates(), r));
+    LOGGER.infof(
+        "License merge: %d from deps.dev + %d from cache = %d total packages",
+        result.packages().size(), cacheHits.size(), merged.size());
     exchange.getIn().setBody(new LicenseSplitResult(result.status(), merged));
   }
 

--- a/src/main/java/io/github/guacsec/trustifyda/integration/licenses/LicensesIntegration.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/licenses/LicensesIntegration.java
@@ -211,11 +211,11 @@ public class LicensesIntegration extends EndpointRouteBuilder {
     // Compare using coordinates since cache uses coordinates as keys
     Set<String> cachedCoordinates =
         cachedLicenses.keySet().stream()
-            .map(p -> p.purl().getCoordinates())
+            .map(p -> DepsDevRequestBuilder.cacheKey(p))
             .collect(Collectors.toSet());
     Set<PackageRef> misses =
         allPurls.stream()
-            .filter(p -> !cachedCoordinates.contains(p.purl().getCoordinates()))
+            .filter(p -> !cachedCoordinates.contains(DepsDevRequestBuilder.cacheKey(p)))
             .collect(Collectors.toSet());
 
     exchange.setProperty(Constants.CACHE_LICENSES_PROPERTY, misses);
@@ -233,7 +233,7 @@ public class LicensesIntegration extends EndpointRouteBuilder {
       cacheHits = Collections.emptyMap();
     }
     Map<String, PackageLicenseResult> packages = new HashMap<>();
-    cacheHits.forEach((ref, result) -> packages.put(ref.purl().getCoordinates(), result));
+    cacheHits.forEach((ref, result) -> packages.put(DepsDevRequestBuilder.cacheKey(ref), result));
     var status = new ProviderStatus().ok(true).name(DEPS_DEV_SOURCE);
     exchange.getIn().setBody(new LicenseSplitResult(status, packages));
   }
@@ -248,7 +248,7 @@ public class LicensesIntegration extends EndpointRouteBuilder {
     LicenseSplitResult result = exchange.getIn().getBody(LicenseSplitResult.class);
     if (result == null) {
       Map<String, PackageLicenseResult> packages = new HashMap<>();
-      cacheHits.forEach((ref, r) -> packages.put(ref.purl().getCoordinates(), r));
+      cacheHits.forEach((ref, r) -> packages.put(DepsDevRequestBuilder.cacheKey(ref), r));
       exchange
           .getIn()
           .setBody(
@@ -257,7 +257,7 @@ public class LicensesIntegration extends EndpointRouteBuilder {
       return;
     }
     Map<String, PackageLicenseResult> merged = new HashMap<>(result.packages());
-    cacheHits.forEach((ref, r) -> merged.put(ref.purl().getCoordinates(), r));
+    cacheHits.forEach((ref, r) -> merged.put(DepsDevRequestBuilder.cacheKey(ref), r));
     LOGGER.infof(
         "License merge: %d from deps.dev + %d from cache = %d total packages",
         result.packages().size(), cacheHits.size(), merged.size());

--- a/src/main/java/io/github/guacsec/trustifyda/integration/licenses/SpdxLicenseService.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/licenses/SpdxLicenseService.java
@@ -37,6 +37,7 @@ import org.spdx.library.model.v3_0_1.expandedlicensing.ListedLicense;
 import org.spdx.library.model.v3_0_1.expandedlicensing.ListedLicenseException;
 import org.spdx.library.model.v3_0_1.expandedlicensing.WithAdditionOperator;
 import org.spdx.library.model.v3_0_1.simplelicensing.AnyLicenseInfo;
+import org.spdx.storage.simple.InMemSpdxStore;
 import org.spdx.utility.compare.LicenseCompareHelper;
 import org.spdx.utility.compare.SpdxCompareException;
 
@@ -183,7 +184,9 @@ public class SpdxLicenseService {
     toParse = toParse.replaceAll("([A-Za-z][A-Za-z0-9.-]*\\d)\\+", "$1-or-later");
     AnyLicenseInfo root;
     try {
-      root = LicenseInfoFactory.parseSPDXLicenseString(toParse);
+      root =
+          LicenseInfoFactory.parseSPDXLicenseString(
+              toParse, new InMemSpdxStore(), null, null, null);
     } catch (InvalidSPDXAnalysisException e) {
       if (!trimmed.contains(" AND ") && !trimmed.contains(" OR ") && !trimmed.contains(" WITH ")) {
         LicenseCategory category = LicenseCategory.UNKNOWN;
@@ -287,7 +290,9 @@ public class SpdxLicenseService {
 
   private List<LicenseIdentifier> parseExpressionToIdentifiers(String expression)
       throws InvalidSPDXAnalysisException {
-    AnyLicenseInfo root = LicenseInfoFactory.parseSPDXLicenseString(expression.trim());
+    AnyLicenseInfo root =
+        LicenseInfoFactory.parseSPDXLicenseString(
+            expression.trim(), new InMemSpdxStore(), null, null, null);
     List<LicenseIdentifier> out = new ArrayList<>();
     collectIdentifiers(root, out);
     return out;


### PR DESCRIPTION
## Summary
- **Root cause fix**: Reduce `BATCH_SIZE` from 500 to 100 to match deps.dev `/v3alpha/purlbatch` API's undocumented 100-item response cap — this was causing license counts to grow across successive requests (e.g. 990 → 1171 → 1218)
- Fix SPDX `InMemSpdxStore` race condition under parallel Camel route processing by using per-call store instances
- Align cache merge keys to use `getCoordinates()` (without PURL qualifiers) for consistent cache hit matching
- Add HTTP status logging (INFO), batch response stats (DEBUG), and merge breakdown logging (INFO)

Resolves: [TC-4749](https://redhat.atlassian.net/browse/TC-4749)
Implements: [TC-4793](https://redhat.atlassian.net/browse/TC-4793)

## Test plan
- [x] All 274 existing tests pass (`mvn test`)
- [x] Spotless formatting passes (`mvn spotless:apply`)
- [ ] Verify stable license counts by running two successive analysis requests for the same SBOM
- [ ] Verify no "Object URI already exists" errors in logs under parallel batch processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TC-4749]: https://redhat.atlassian.net/browse/TC-4749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TC-4793]: https://redhat.atlassian.net/browse/TC-4793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Align deps.dev license integration with API limits and improve robustness of license parsing and caching.

Bug Fixes:
- Limit deps.dev batch requests to 100 items to match the API response cap and prevent incorrect license aggregation.
- Use a fresh InMemSpdxStore per SPDX parse to avoid race conditions under parallel processing.
- Normalize license cache keys to use purl coordinates for consistent cache hit and merge behavior.

Enhancements:
- Log deps.dev HTTP status codes and batch response statistics, including counts of responses with and without license data.
- Log license merge statistics when combining deps.dev results with cache hits.