### PR TITLE
fix(api): map null severity to unknown counter

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/ProviderResponseHandler.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/ProviderResponseHandler.java
@@ -514,7 +514,9 @@ public abstract class ProviderResponseHandler {
             i -> {
               var vulnerabilities = countVulnerabilities(i);
               var severity = i.getSeverity();
-              if (severity != null) {
+              if (severity == null) {
+                counter.unknown.addAndGet(vulnerabilities);
+              } else {
                 switch (severity) {
                   case CRITICAL -> counter.critical.addAndGet(vulnerabilities);
                   case HIGH -> counter.high.addAndGet(vulnerabilities);


### PR DESCRIPTION
## Summary

- Follow-up to #621 — the `unknown` severity counter was added but `ProviderResponseHandler` still had `if (severity != null)` which skipped null-severity vulnerabilities entirely
- Flips the guard so null severity increments the `unknown` counter, fixing the invariant `total == critical + high + medium + low + unknown`

## Test plan

- [x] `ProviderResponseHandlerTest` passes
- [ ] Integration tests pass after staging redeployment (tracked in exhort-integration-tests PR #37)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Map vulnerabilities with null severity to the unknown severity counter instead of skipping them.