### PR TITLE
feat(hardened): wire hardened image recommendations into analysis pipeline

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/integration/Constants.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/Constants.java
@@ -87,6 +87,7 @@ public final class Constants {
   public static final String CACHE_LICENSES_HITS_PROPERTY = "cacheLicensesHits";
 
   public static final String TRUSTIFY_RECOMMEND_PATH = "/api/v2/purl/recommend";
+  public static final String TRUSTIFY_HARDENED_RECOMMEND_ROUTE = "hardenedRecommendations";
   public static final String TRUSTIFY_ANALYZE_PATH = "/api/v2/vulnerability/analyze";
   public static final String TRUSTIFY_HEALTH_PATH = "/.well-known/trustify";
 

--- a/src/main/java/io/github/guacsec/trustifyda/integration/Constants.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/Constants.java
@@ -87,7 +87,6 @@ public final class Constants {
   public static final String CACHE_LICENSES_HITS_PROPERTY = "cacheLicensesHits";
 
   public static final String TRUSTIFY_RECOMMEND_PATH = "/api/v2/purl/recommend";
-  public static final String TRUSTIFY_HARDENED_RECOMMEND_ROUTE = "hardenedRecommendations";
   public static final String TRUSTIFY_ANALYZE_PATH = "/api/v2/vulnerability/analyze";
   public static final String TRUSTIFY_HEALTH_PATH = "/.well-known/trustify";
 

--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyIntegration.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyIntegration.java
@@ -41,6 +41,7 @@ import io.github.guacsec.trustifyda.api.PackageRef;
 import io.github.guacsec.trustifyda.integration.Constants;
 import io.github.guacsec.trustifyda.integration.cache.CacheService;
 import io.github.guacsec.trustifyda.integration.providers.VulnerabilityProvider;
+import io.github.guacsec.trustifyda.integration.providers.trustify.hardened.HardenedImageProvider;
 import io.github.guacsec.trustifyda.integration.providers.trustify.ubi.UBIRecommendation;
 import io.github.guacsec.trustifyda.model.DependencyTree;
 import io.github.guacsec.trustifyda.model.PackageItem;
@@ -84,6 +85,7 @@ public class TrustifyIntegration extends EndpointRouteBuilder {
   @Inject TrustifyRequestBuilder requestBuilder;
   @Inject ObjectMapper mapper;
   @Inject UBIRecommendation ubiRecommendation;
+  @Inject HardenedImageProvider hardenedImageProvider;
   @Inject MeterRegistry registry;
   @Inject CacheService cacheService;
 
@@ -152,7 +154,17 @@ public class TrustifyIntegration extends EndpointRouteBuilder {
         .setProperty(Constants.CIRCUIT_BREAKER_FALLBACK_WITH_TIMEOUT, constant(true))
         .process(responseHandler::processResponseError)
       .endChoice()
-      
+
+      .end();
+
+    from(direct(Constants.TRUSTIFY_HARDENED_RECOMMEND_ROUTE))
+      .routeId("trustify-hardened-recommend")
+      .routePolicy(new ProviderRoutePolicy(registry))
+      .choice()
+        .when(exchangeProperty(Constants.RECOMMEND_PARAM).isEqualTo(Boolean.TRUE))
+          .process(this::processHardenedRecommendations)
+        .otherwise()
+          .setBody(constant(Collections.emptyMap()))
       .end();
 
     from(direct("vulnerabilities"))
@@ -180,6 +192,7 @@ public class TrustifyIntegration extends EndpointRouteBuilder {
         .parallelProcessing()
           .to(direct("vulnerabilities"))
           .to(direct("recommendations"))
+          .to(direct(Constants.TRUSTIFY_HARDENED_RECOMMEND_ROUTE))
       .end();
 
     from(direct("trustifyHealthCheck"))
@@ -416,6 +429,11 @@ public class TrustifyIntegration extends EndpointRouteBuilder {
       return Collections.singletonMap(pkgRef, recommendation);
     }
     return Collections.emptyMap();
+  }
+
+  private void processHardenedRecommendations(Exchange exchange) {
+    String sbomId = exchange.getProperty(Constants.SBOM_ID_PROPERTY, String.class);
+    exchange.getMessage().setBody(hardenedImageProvider.lookupBySbomId(sbomId));
   }
 
   private Vulnerability filterFixed(Vulnerability a, Vulnerability b) {

--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyIntegration.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/TrustifyIntegration.java
@@ -157,7 +157,7 @@ public class TrustifyIntegration extends EndpointRouteBuilder {
 
       .end();
 
-    from(direct(Constants.TRUSTIFY_HARDENED_RECOMMEND_ROUTE))
+    from(direct("hardenedRecommendations"))
       .routeId("trustify-hardened-recommend")
       .routePolicy(new ProviderRoutePolicy(registry))
       .choice()
@@ -192,7 +192,7 @@ public class TrustifyIntegration extends EndpointRouteBuilder {
         .parallelProcessing()
           .to(direct("vulnerabilities"))
           .to(direct("recommendations"))
-          .to(direct(Constants.TRUSTIFY_HARDENED_RECOMMEND_ROUTE))
+          .to(direct("hardenedRecommendations"))
       .end();
 
     from(direct("trustifyHealthCheck"))

--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageProvider.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageProvider.java
@@ -145,7 +145,13 @@ public class HardenedImageProvider {
       return Collections.emptyMap();
     }
 
-    var pkgRef = new PackageRef(sbomId);
+    PackageRef pkgRef;
+    try {
+      pkgRef = new PackageRef(sbomId);
+    } catch (IllegalArgumentException e) {
+      LOG.warnf("Skipping malformed PURL in lookupBySbomId: %s", sbomId);
+      return Collections.emptyMap();
+    }
     if (!OCI_PURL_TYPE.equals(pkgRef.purl().getType())) {
       return Collections.emptyMap();
     }

--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageProvider.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageProvider.java
@@ -44,6 +44,7 @@ public class HardenedImageProvider {
 
   private static final Logger LOG = Logger.getLogger(HardenedImageProvider.class);
   private static final String LOCK_KEY = "hardened-image-refresh-lock";
+  private static final String OCI_PURL_TYPE = "oci";
 
   private final HardenedImageIndex index = new HardenedImageIndex();
   private final HardenedImageRecommendation config;
@@ -119,8 +120,6 @@ public class HardenedImageProvider {
       }
     }
   }
-
-  private static final String OCI_PURL_TYPE = "oci";
 
   /**
    * Looks up a hardened image recommendation for the given base image reference.

--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageProvider.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageProvider.java
@@ -18,11 +18,13 @@
 package io.github.guacsec.trustifyda.integration.providers.trustify.hardened;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.jboss.logging.Logger;
 
+import io.github.guacsec.trustifyda.api.PackageRef;
 import io.github.guacsec.trustifyda.integration.lock.LockService;
 import io.github.guacsec.trustifyda.model.trustify.HardenedImageIndex;
 import io.github.guacsec.trustifyda.model.trustify.IndexedRecommendation;
@@ -30,6 +32,7 @@ import io.quarkus.rest.client.reactive.QuarkusRestClientBuilder;
 import io.quarkus.scheduler.Scheduled;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 /**
  * Provider that periodically fetches hardened image compatibility data from the Hummingbird service
@@ -48,6 +51,7 @@ public class HardenedImageProvider {
   private final HardenedImageResponseHandler responseHandler;
   private final HummingbirdClient hummingbirdClient;
 
+  @Inject
   public HardenedImageProvider(
       HardenedImageRecommendation config,
       LockService lock,
@@ -116,6 +120,8 @@ public class HardenedImageProvider {
     }
   }
 
+  private static final String OCI_PURL_TYPE = "oci";
+
   /**
    * Looks up a hardened image recommendation for the given base image reference.
    *
@@ -124,6 +130,58 @@ public class HardenedImageProvider {
    */
   public IndexedRecommendation lookup(String baseImageRef) {
     return index.get(baseImageRef);
+  }
+
+  /**
+   * Resolves hardened image recommendations for an SBOM identified by its PURL. Parses the PURL to
+   * extract the Docker-style base image reference and looks it up in the index. Returns an empty
+   * map if the PURL is not an OCI type, has no repository_url qualifier, or no match is found.
+   *
+   * @param sbomId the SBOM identifier (an OCI PURL string)
+   * @return a map of package ref to recommendation, or empty if no match
+   */
+  public Map<PackageRef, IndexedRecommendation> lookupBySbomId(String sbomId) {
+    if (sbomId == null) {
+      return Collections.emptyMap();
+    }
+
+    var pkgRef = new PackageRef(sbomId);
+    if (!OCI_PURL_TYPE.equals(pkgRef.purl().getType())) {
+      return Collections.emptyMap();
+    }
+
+    String baseImageRef = buildDockerRef(pkgRef);
+    if (baseImageRef == null) {
+      return Collections.emptyMap();
+    }
+
+    var recommendation = lookup(baseImageRef);
+    if (recommendation == null) {
+      return Collections.emptyMap();
+    }
+
+    return Map.of(pkgRef, recommendation);
+  }
+
+  /**
+   * Constructs a Docker-style image reference from an OCI PURL's repository_url and tag qualifiers.
+   * For example, {@code pkg:oci/nginx@sha256:abc?repository_url=docker.io/library/nginx&tag=1.25}
+   * produces {@code docker.io/library/nginx:1.25}.
+   */
+  private String buildDockerRef(PackageRef pkgRef) {
+    var qualifiers = pkgRef.purl().getQualifiers();
+    if (qualifiers == null) {
+      return null;
+    }
+    String repoUrl = qualifiers.get("repository_url");
+    if (repoUrl == null || repoUrl.isBlank()) {
+      return null;
+    }
+    String tag = qualifiers.get("tag");
+    if (tag != null && !tag.isBlank()) {
+      return repoUrl + ":" + tag;
+    }
+    return repoUrl;
   }
 
   /** Returns the current index for inspection. */

--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageResponseHandler.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageResponseHandler.java
@@ -17,14 +17,18 @@
 
 package io.github.guacsec.trustifyda.integration.providers.trustify.hardened;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.packageurl.PackageURL;
 
 import io.github.guacsec.trustifyda.api.PackageRef;
 import io.github.guacsec.trustifyda.model.trustify.IndexedRecommendation;
@@ -55,14 +59,18 @@ public class HardenedImageResponseHandler {
     JsonNode root = objectMapper.readTree(json);
     Map<String, IndexedRecommendation> invertedIndex = new HashMap<>();
 
-    JsonNode images = root.isArray() ? root : root.path("images");
-    if (images.isMissingNode() || !images.isArray()) {
-      LOG.warn("Hummingbird response has no images array, returning empty index");
+    JsonNode images = root.path("images");
+    if (images.isMissingNode() || !images.isObject()) {
+      LOG.warn("Hummingbird response has no images object, returning empty index");
       return Collections.emptyMap();
     }
 
-    for (JsonNode imageNode : images) {
-      String hardenedRef = imageNode.path("image_ref").asText(null);
+    var fields = images.fields();
+    while (fields.hasNext()) {
+      var entry = fields.next();
+      String hardenedRef = entry.getKey();
+      JsonNode imageNode = entry.getValue();
+
       if (hardenedRef == null || hardenedRef.isBlank()) {
         continue;
       }
@@ -74,9 +82,9 @@ public class HardenedImageResponseHandler {
 
       PackageRef hardenedPackage;
       try {
-        hardenedPackage = new PackageRef(hardenedRef);
-      } catch (IllegalArgumentException e) {
-        LOG.warnf("Skipping invalid PURL in Hummingbird response: %s", hardenedRef);
+        hardenedPackage = containerRefToPackageRef(hardenedRef);
+      } catch (Exception e) {
+        LOG.warnf("Skipping unparseable image ref in Hummingbird response: %s", hardenedRef);
         continue;
       }
       IndexedRecommendation recommendation =
@@ -95,5 +103,39 @@ public class HardenedImageResponseHandler {
     }
 
     return invertedIndex;
+  }
+
+  /**
+   * Converts a container image reference (e.g., {@code quay.io/hummingbird/aspnet-runtime:10}) to
+   * an OCI Package URL. The full image path becomes the {@code repository_url} qualifier and the
+   * tag (if present) becomes the {@code tag} qualifier.
+   */
+  static PackageRef containerRefToPackageRef(String imageRef) throws Exception {
+    String path;
+    String tag = null;
+
+    int atIndex = imageRef.indexOf('@');
+    if (atIndex >= 0) {
+      path = imageRef.substring(0, atIndex);
+    } else {
+      int colonIndex = imageRef.lastIndexOf(':');
+      if (colonIndex > imageRef.lastIndexOf('/')) {
+        path = imageRef.substring(0, colonIndex);
+        tag = imageRef.substring(colonIndex + 1);
+      } else {
+        path = imageRef;
+      }
+    }
+
+    String name = path.substring(path.lastIndexOf('/') + 1);
+    String repoUrl = URLEncoder.encode(path, StandardCharsets.UTF_8);
+
+    TreeMap<String, String> qualifiers = new TreeMap<>();
+    qualifiers.put("repository_url", repoUrl);
+    if (tag != null) {
+      qualifiers.put("tag", tag);
+    }
+
+    return new PackageRef(new PackageURL("oci", null, name, null, qualifiers, null));
   }
 }

--- a/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageIntegrationTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageIntegrationTest.java
@@ -61,7 +61,7 @@ import jakarta.ws.rs.core.MediaType;
 @QuarkusTestResource(OidcWiremockExtension.class)
 public class HardenedImageIntegrationTest {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  @Inject ObjectMapper mapper;
   private static final String OK_TOKEN = "test-token";
   private static final String TRUSTIFY_PROVIDER = "trustify";
 
@@ -214,7 +214,7 @@ public class HardenedImageIntegrationTest {
             .asString();
 
     Map<String, AnalysisReport> response =
-        MAPPER.readValue(body, new TypeReference<Map<String, AnalysisReport>>() {});
+        mapper.readValue(body, new TypeReference<Map<String, AnalysisReport>>() {});
 
     // Then no hardened recommendations appear in the response
     assertNotNull(response);
@@ -295,7 +295,7 @@ public class HardenedImageIntegrationTest {
             .extract()
             .body()
             .asString();
-    return MAPPER.readValue(body, new TypeReference<Map<String, AnalysisReport>>() {});
+    return mapper.readValue(body, new TypeReference<Map<String, AnalysisReport>>() {});
   }
 
   /**
@@ -340,6 +340,6 @@ public class HardenedImageIntegrationTest {
             List.of(component),
             "dependencies",
             List.of(rootDep, leafDep));
-    return MAPPER.writeValueAsString(Map.of(ociPurl, sbom));
+    return mapper.writeValueAsString(Map.of(ociPurl, sbom));
   }
 }

--- a/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageIntegrationTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageIntegrationTest.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2023-2025 Trustify Dependency Analytics Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.guacsec.trustifyda.integration.providers.trustify.hardened;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.camel.Exchange;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+
+import io.github.guacsec.trustifyda.api.PackageRef;
+import io.github.guacsec.trustifyda.api.v5.AnalysisReport;
+import io.github.guacsec.trustifyda.extensions.InjectWireMock;
+import io.github.guacsec.trustifyda.extensions.OidcWiremockExtension;
+import io.github.guacsec.trustifyda.integration.Constants;
+import io.github.guacsec.trustifyda.model.trustify.IndexedRecommendation;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * WireMock-based integration tests for the hardened image recommendation pipeline. Verifies that
+ * hardened image recommendations from the HardenedImageProvider are wired into the Camel multicast
+ * and appear in analysis responses.
+ */
+@QuarkusTest
+@QuarkusTestResource(OidcWiremockExtension.class)
+public class HardenedImageIntegrationTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String OK_TOKEN = "test-token";
+  private static final String TRUSTIFY_PROVIDER = "trustify";
+
+  private static final String NGINX_BASE_REF = "docker.io/library/nginx:1.25";
+  private static final String HARDENED_NGINX_PURL =
+      "pkg:oci/hardened-nginx@sha256:abc123?repository_url=registry.example.com%2Fhardened-nginx&tag=1.25";
+
+  /**
+   * OCI PURL used as the batch SBOM key (sbomId). The repository_url and tag qualifiers allow
+   * reconstruction of the Docker reference for index lookup.
+   */
+  private static final String OCI_SBOM_ID =
+      "pkg:oci/nginx@sha256:def456?repository_url=docker.io%2Flibrary%2Fnginx&tag=1.25";
+
+  /** An OCI PURL whose base image is NOT in the hardened index. */
+  private static final String OCI_SBOM_ID_NO_MATCH =
+      "pkg:oci/alpine@sha256:ghi789?repository_url=docker.io%2Flibrary%2Falpine&tag=3.19";
+
+  private static final String HARDENED_SOURCE = "hardened";
+
+  private static final String MAVEN_COMPONENT_PURL =
+      "pkg:maven/io.quarkus/quarkus-core@2.13.5.Final?type=jar";
+
+  @InjectWireMock WireMockServer server;
+
+  @Inject HardenedImageProvider hardenedImageProvider;
+
+  @Inject MeterRegistry meterRegistry;
+
+  @Inject RedisDataSource redisDataSource;
+
+  @BeforeEach
+  void setup() {
+    if (redisDataSource != null) {
+      redisDataSource.flushall();
+    }
+    if (server != null) {
+      OidcWiremockExtension.restubOidcEndpoints(server);
+    }
+    populateHardenedIndex();
+    stubTrustifyEndpoints();
+  }
+
+  @AfterEach
+  void teardown() {
+    if (server != null) {
+      server.resetAll();
+    }
+  }
+
+  /** Pre-populates the hardened image index with test data. */
+  private void populateHardenedIndex() {
+    PackageRef hardenedPkg = new PackageRef(HARDENED_NGINX_PURL);
+    IndexedRecommendation recommendation =
+        IndexedRecommendation.builder()
+            .packageName(hardenedPkg)
+            .vulnerabilities(Collections.emptyMap())
+            .sourceName(HARDENED_SOURCE)
+            .build();
+    hardenedImageProvider.getIndex().replaceAll(Map.of(NGINX_BASE_REF, recommendation));
+  }
+
+  /** Stubs the Trustify vulnerability and recommendation endpoints in WireMock. */
+  private void stubTrustifyEndpoints() {
+    // Stub vulnerability analysis endpoint
+    server.stubFor(
+        post(Constants.TRUSTIFY_ANALYZE_PATH)
+            .withHeader(Constants.AUTHORIZATION_HEADER, equalTo("Bearer " + OK_TOKEN))
+            .withHeader(Exchange.CONTENT_TYPE, containing(MediaType.APPLICATION_JSON))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader(Exchange.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBodyFile("trustify/empty_report.json")));
+
+    // Stub recommendation endpoint
+    server.stubFor(
+        post(Constants.TRUSTIFY_RECOMMEND_PATH)
+            .withHeader(Constants.AUTHORIZATION_HEADER, equalTo("Bearer " + OK_TOKEN))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader(Exchange.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBodyFile("trustedcontent/empty_report.json")));
+
+    // Stub deps.dev licenses endpoint
+    server.stubFor(
+        post(Constants.DEPS_DEV_LICENSES_PATH)
+            .willReturn(aResponse().withStatus(200).withBodyFile("depsdev/maven_response.json")));
+  }
+
+  /**
+   * Verifies that a batch analysis request with an OCI image that has a hardened recommendation
+   * returns the recommendation in the response with recommendationSource = "hardened".
+   */
+  @Test
+  void testHardenedRecommendationIncludedInResponse() throws Exception {
+    // Given an OCI SBOM that matches a hardened recommendation in the index
+
+    // When sending a batch analysis with the matching OCI SBOM
+    String batchBody = createOciBatchRequest(OCI_SBOM_ID);
+    Map<String, AnalysisReport> response = sendBatchAnalysis(batchBody);
+
+    // Then the response contains the hardened recommendation
+    assertNotNull(response, "Response should not be null");
+
+    var report = response.values().iterator().next();
+    var trustifyResult = report.getProviders().get(TRUSTIFY_PROVIDER);
+    assertNotNull(trustifyResult, "Trustify provider result should not be null");
+
+    var recommendations = trustifyResult.getRecommendations();
+    assertNotNull(recommendations, "Recommendations map should not be null");
+    assertTrue(
+        recommendations.containsKey(HARDENED_SOURCE),
+        "Recommendations should contain 'hardened' source");
+
+    var hardenedRec = recommendations.get(HARDENED_SOURCE);
+    assertNotNull(hardenedRec, "Hardened recommendation source should not be null");
+    assertNotNull(
+        hardenedRec.getDependencies(), "Hardened recommendation dependencies should not be null");
+    assertTrue(
+        hardenedRec.getDependencies().size() > 0,
+        "Hardened recommendation should have at least one dependency");
+  }
+
+  /**
+   * Verifies that hardened image recommendations are skipped when the recommend=false query
+   * parameter is set.
+   */
+  @Test
+  void testHardenedRecommendationSkippedWhenRecommendFalse() throws Exception {
+    // Given an OCI SBOM with a hardened recommendation available
+
+    // When sending a batch analysis with recommend=false
+    String batchBody = createOciBatchRequest(OCI_SBOM_ID);
+    String body =
+        given()
+            .header("Content-Type", Constants.CYCLONEDX_MEDIATYPE_JSON)
+            .header("Accept", MediaType.APPLICATION_JSON)
+            .header(Constants.TRUSTIFY_TOKEN_HEADER, OK_TOKEN)
+            .queryParam(Constants.RECOMMEND_PARAM, false)
+            .body(batchBody)
+            .when()
+            .post("/api/v5/batch-analysis")
+            .then()
+            .assertThat()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+
+    Map<String, AnalysisReport> response =
+        MAPPER.readValue(body, new TypeReference<Map<String, AnalysisReport>>() {});
+
+    // Then no hardened recommendations appear in the response
+    assertNotNull(response);
+    for (var report : response.values()) {
+      var providers = report.getProviders();
+      if (providers == null) continue;
+      var trustifyResult = providers.get(TRUSTIFY_PROVIDER);
+      if (trustifyResult == null) continue;
+      var recommendations = trustifyResult.getRecommendations();
+      assertTrue(
+          recommendations == null || !recommendations.containsKey(HARDENED_SOURCE),
+          "No hardened recommendations should appear when recommend=false");
+    }
+  }
+
+  /**
+   * Verifies that an analysis request for an OCI image without a hardened recommendation returns no
+   * hardened recommendation in the response.
+   */
+  @Test
+  void testNoHardenedRecommendationForUnmatchedImage() throws Exception {
+    // Given an OCI SBOM whose image is NOT in the hardened index
+
+    // When sending a batch analysis with the unmatched OCI image
+    String batchBody = createOciBatchRequest(OCI_SBOM_ID_NO_MATCH);
+    Map<String, AnalysisReport> response = sendBatchAnalysis(batchBody);
+
+    // Then no hardened recommendations appear
+    assertNotNull(response);
+    for (var report : response.values()) {
+      var providers = report.getProviders();
+      if (providers == null) continue;
+      var trustifyResult = providers.get(TRUSTIFY_PROVIDER);
+      if (trustifyResult == null) continue;
+      var recommendations = trustifyResult.getRecommendations();
+      assertTrue(
+          recommendations == null
+              || recommendations.isEmpty()
+              || !recommendations.containsKey(HARDENED_SOURCE),
+          "No hardened recommendation should appear for unmatched image");
+    }
+  }
+
+  /**
+   * Verifies that the Prometheus timer metric is recorded for the hardened recommendation route
+   * after an analysis request.
+   */
+  @Test
+  void testPrometheusMetricsRecordedForHardenedRoute() throws Exception {
+    // Given an OCI SBOM
+
+    // When sending a batch analysis request
+    String batchBody = createOciBatchRequest(OCI_SBOM_ID);
+    sendBatchAnalysis(batchBody);
+
+    // Then Prometheus metrics are recorded for the hardened recommendation route
+    var timer =
+        meterRegistry
+            .find("camel.route.provider.requests")
+            .tag("routeId", "trustify-hardened-recommend")
+            .timer();
+    assertNotNull(timer, "Prometheus timer should exist for the trustify-hardened-recommend route");
+  }
+
+  /** Sends a batch analysis request and returns the parsed response map. */
+  private Map<String, AnalysisReport> sendBatchAnalysis(String batchBody) throws Exception {
+    String body =
+        given()
+            .header("Content-Type", Constants.CYCLONEDX_MEDIATYPE_JSON)
+            .header("Accept", MediaType.APPLICATION_JSON)
+            .header(Constants.TRUSTIFY_TOKEN_HEADER, OK_TOKEN)
+            .body(batchBody)
+            .when()
+            .post("/api/v5/batch-analysis")
+            .then()
+            .assertThat()
+            .statusCode(200)
+            .extract()
+            .body()
+            .asString();
+    return MAPPER.readValue(body, new TypeReference<Map<String, AnalysisReport>>() {});
+  }
+
+  /**
+   * Creates a minimal batch request body with a single OCI CycloneDX SBOM entry. The SBOM contains
+   * no real dependencies — the purpose is to exercise the hardened recommendation lookup via the
+   * sbomId (the batch map key).
+   */
+  private String createOciBatchRequest(String ociPurl) throws Exception {
+    var component =
+        Map.of(
+            "name",
+            "quarkus-core",
+            "purl",
+            MAVEN_COMPONENT_PURL,
+            "type",
+            "library",
+            "bom-ref",
+            MAVEN_COMPONENT_PURL);
+    var rootDep = Map.of("ref", ociPurl, "dependsOn", List.of(MAVEN_COMPONENT_PURL));
+    var leafDep = Map.of("ref", MAVEN_COMPONENT_PURL, "dependsOn", List.of());
+    var sbom =
+        Map.of(
+            "bomFormat",
+            "CycloneDX",
+            "specVersion",
+            "1.4",
+            "version",
+            1,
+            "metadata",
+            Map.of(
+                "component",
+                Map.of(
+                    "name",
+                    "test-image",
+                    "purl",
+                    ociPurl,
+                    "type",
+                    "container",
+                    "bom-ref",
+                    ociPurl)),
+            "components",
+            List.of(component),
+            "dependencies",
+            List.of(rootDep, leafDep));
+    return MAPPER.writeValueAsString(Map.of(ociPurl, sbom));
+  }
+}

--- a/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageProviderTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageProviderTest.java
@@ -52,12 +52,6 @@ public class HardenedImageProviderTest {
   private static final String LOCK_KEY = "hardened-image-refresh-lock";
   private static final String HARDENED_NGINX_PURL =
       "pkg:oci/hardened-nginx@sha256:abc123?repository_url=registry.example.com/hardened-nginx&tag=1.25";
-  private static final String HARDENED_PYTHON_PURL =
-      "pkg:oci/hardened-python@sha256:def456?repository_url=registry.example.com/hardened-python&tag=3.12";
-  private static final String HARDENED_NODE_PURL =
-      "pkg:oci/hardened-node@sha256:ghi789?repository_url=registry.example.com/hardened-node&tag=20";
-  private static final String HARDENED_ALPINE_PURL =
-      "pkg:oci/hardened-alpine@sha256:jkl012?repository_url=registry.example.com/hardened-alpine&tag=3.19";
 
   /** Normalized PURL as produced by PackageURL (URL-encodes special characters). */
   private static String normalized(String rawPurl) {
@@ -82,7 +76,7 @@ public class HardenedImageProviderTest {
     provider = new HardenedImageProvider(config, lock, responseHandler, hummingbirdClient);
   }
 
-  /// Verifies that the periodic refresh acquires the lock, fetches data, and populates the index.
+  // Verifies that the periodic refresh acquires the lock, fetches data, and populates the index.
   @Test
   void testRefreshAcquiresLockAndPopulatesIndex() throws Exception {
     // Given a configured URL and a lock that this instance acquires
@@ -119,7 +113,7 @@ public class HardenedImageProviderTest {
     assertEquals("hardened", spyProvider.lookup("docker.io/library/nginx:1.25").sourceName());
   }
 
-  /// Verifies that a second instance skips refresh when the lock is already held.
+  // Verifies that a second instance skips refresh when the lock is already held.
   @Test
   void testLockContentionSkipsRefresh() {
     // Given a configured URL but the lock is held by another instance
@@ -133,39 +127,39 @@ public class HardenedImageProviderTest {
     assertEquals(0, provider.getIndex().size());
   }
 
-  /// Verifies that Hummingbird response parsing correctly inverts the compare_to mapping.
+  // Verifies that Hummingbird response parsing correctly inverts the compare_to mapping.
   @Test
   void testParseAndInvertMapping() throws Exception {
-    // Given a Hummingbird response with multiple hardened images
+    // Given a Hummingbird response with container image refs as keys (not PURLs)
     String json =
-        "[{\"image_ref\": \""
-            + HARDENED_PYTHON_PURL
-            + "\","
-            + "\"compare_to\": [\"docker.io/library/python:3.12\","
+        "{\"images\": {"
+            + "\"registry.example.com/hardened-python:3.12\":"
+            + " {\"compare_to\": [\"docker.io/library/python:3.12\","
             + " \"docker.io/library/python:3.12-slim\"]},"
-            + "{\"image_ref\": \""
-            + HARDENED_NODE_PURL
-            + "\","
-            + "\"compare_to\": [\"docker.io/library/node:20\"]}]";
+            + "\"registry.example.com/hardened-node:20\":"
+            + " {\"compare_to\": [\"docker.io/library/node:20\"]}}}";
 
     // When parsing and inverting the mapping
     Map<String, IndexedRecommendation> result = responseHandler.parseAndInvertMapping(json);
 
-    // Then each base image maps to its hardened recommendation
+    // Then each base image maps to its hardened recommendation with an OCI PURL
     assertEquals(3, result.size());
+    var pythonRec = result.get("docker.io/library/python:3.12");
+    assertNotNull(pythonRec);
+    assertEquals("oci", pythonRec.packageName().purl().getType());
+    assertEquals("hardened-python", pythonRec.packageName().purl().getName());
     assertEquals(
-        normalized(HARDENED_PYTHON_PURL),
-        result.get("docker.io/library/python:3.12").packageName().ref());
-    assertEquals(
-        normalized(HARDENED_PYTHON_PURL),
+        pythonRec.packageName().ref(),
         result.get("docker.io/library/python:3.12-slim").packageName().ref());
-    assertEquals(
-        normalized(HARDENED_NODE_PURL),
-        result.get("docker.io/library/node:20").packageName().ref());
-    assertEquals("hardened", result.get("docker.io/library/node:20").sourceName());
+
+    var nodeRec = result.get("docker.io/library/node:20");
+    assertNotNull(nodeRec);
+    assertEquals("oci", nodeRec.packageName().purl().getType());
+    assertEquals("hardened-node", nodeRec.packageName().purl().getName());
+    assertEquals("hardened", nodeRec.sourceName());
   }
 
-  /// Verifies that the provider returns empty results when the Hummingbird URL is not configured.
+  // Verifies that the provider returns empty results when the Hummingbird URL is not configured.
   @Test
   void testDisabledWhenUrlNotConfigured() {
     // Given no Hummingbird URL configured
@@ -179,7 +173,7 @@ public class HardenedImageProviderTest {
     assertNull(provider.lookup("docker.io/library/nginx:1.25"));
   }
 
-  /// Verifies that the lock is released after a successful data load.
+  // Verifies that the lock is released after a successful data load.
   @Test
   void testLockReleasedAfterSuccessfulLoad() throws Exception {
     // Given a configured URL and a lock that this instance acquires
@@ -206,31 +200,31 @@ public class HardenedImageProviderTest {
     assertNotNull(spyProvider.lookup("base:1.0"));
   }
 
-  /// Verifies that parsing handles a nested object format with an "images" key.
+  // Verifies that parsing handles the standard Hummingbird object format with container ref keys.
   @Test
-  void testParseNestedObjectFormat() throws Exception {
-    // Given a Hummingbird response using nested object format
+  void testParseObjectFormat() throws Exception {
+    // Given a Hummingbird response with a container image ref as key
     String json =
-        "{\"images\": [{\"image_ref\": \""
-            + HARDENED_ALPINE_PURL
-            + "\","
-            + "\"compare_to\": [\"docker.io/library/alpine:3.19\"]}]}";
+        "{\"images\": {"
+            + "\"registry.example.com/hardened-alpine:3.19\":"
+            + " {\"compare_to\": [\"docker.io/library/alpine:3.19\"]}}}";
 
     // When parsing
     Map<String, IndexedRecommendation> result = responseHandler.parseAndInvertMapping(json);
 
-    // Then the mapping is correctly inverted
+    // Then the mapping is correctly inverted with an OCI PURL
     assertEquals(1, result.size());
-    assertEquals(
-        normalized(HARDENED_ALPINE_PURL),
-        result.get("docker.io/library/alpine:3.19").packageName().ref());
+    var rec = result.get("docker.io/library/alpine:3.19");
+    assertNotNull(rec);
+    assertEquals("oci", rec.packageName().purl().getType());
+    assertEquals("hardened-alpine", rec.packageName().purl().getName());
   }
 
-  /// Verifies that parsing returns empty index for responses with no images.
+  // Verifies that parsing returns empty index for responses with no images.
   @Test
   void testParseEmptyResponse() throws Exception {
     // Given an empty Hummingbird response
-    String json = "{\"images\": []}";
+    String json = "{\"images\": {}}";
 
     // When parsing
     Map<String, IndexedRecommendation> result = responseHandler.parseAndInvertMapping(json);
@@ -239,19 +233,16 @@ public class HardenedImageProviderTest {
     assertTrue(result.isEmpty());
   }
 
-  /// Verifies that entries with blank image_ref or invalid PURLs are skipped.
+  // Verifies that entries with blank keys or missing compare_to are skipped.
   @Test
   void testParseSkipsInvalidEntries() throws Exception {
-    // Given a response with some invalid entries
+    // Given a response with some invalid entries (blank key, missing compare_to)
     String json =
-        "[{\"image_ref\": \"\", \"compare_to\": [\"base:1.0\"]},"
-            + "{\"image_ref\": \"not-a-valid-purl\", \"compare_to\": [\"base:2.0\"]},"
-            + "{\"image_ref\": \""
-            + HARDENED_NGINX_PURL
-            + "\", \"compare_to\": [\"base:3.0\"]},"
-            + "{\"image_ref\": \""
-            + HARDENED_PYTHON_PURL
-            + "\"}]";
+        "{\"images\": {"
+            + "\"\": {\"compare_to\": [\"base:1.0\"]},"
+            + "\"registry.example.com/hardened-nginx:1.25\":"
+            + " {\"compare_to\": [\"base:3.0\"]},"
+            + "\"registry.example.com/hardened-python:3.12\": {}}}";
 
     // When parsing
     Map<String, IndexedRecommendation> result = responseHandler.parseAndInvertMapping(json);
@@ -260,10 +251,9 @@ public class HardenedImageProviderTest {
     assertEquals(1, result.size());
     assertNotNull(result.get("base:3.0"));
     assertNull(result.get("base:1.0"));
-    assertNull(result.get("base:2.0"));
   }
 
-  /// Verifies that a populated index is preserved when Hummingbird returns empty data.
+  // Verifies that a populated index is preserved when Hummingbird returns empty data.
   @Test
   void testEmptyResponsePreservesExistingIndex() throws Exception {
     // Given a configured URL and a lock that this instance acquires
@@ -294,7 +284,7 @@ public class HardenedImageProviderTest {
     assertNotNull(spyProvider.lookup("base:1.0"));
   }
 
-  /// Verifies that a populated index is preserved when fetchAndParseData throws an exception.
+  // Verifies that a populated index is preserved when fetchAndParseData throws an exception.
   @Test
   void testFetchFailurePreservesExistingIndex() throws Exception {
     // Given a configured URL and a lock that this instance acquires
@@ -326,7 +316,7 @@ public class HardenedImageProviderTest {
     verify(lock, atLeastOnce()).release(LOCK_KEY);
   }
 
-  /// Verifies that lock release failure does not propagate and the index remains intact.
+  // Verifies that lock release failure does not propagate and the index remains intact.
   @Test
   void testLockReleaseFailureDoesNotPropagate() throws Exception {
     // Given a configured URL and a lock that this instance acquires
@@ -354,7 +344,7 @@ public class HardenedImageProviderTest {
     assertNotNull(spyProvider.lookup("base:1.0"));
   }
 
-  /// Verifies that lookupBySbomId returns the recommendation for a matching OCI PURL.
+  // Verifies that lookupBySbomId returns the recommendation for a matching OCI PURL.
   @Test
   void testLookupBySbomIdMatchingOciPurl() {
     // Given an index populated with a hardened nginx recommendation
@@ -378,7 +368,7 @@ public class HardenedImageProviderTest {
     assertEquals("hardened", entry.getValue().sourceName());
   }
 
-  /// Verifies that lookupBySbomId returns empty for a non-OCI PURL.
+  // Verifies that lookupBySbomId returns empty for a non-OCI PURL.
   @Test
   void testLookupBySbomIdNonOciPurl() {
     // Given any index state
@@ -389,19 +379,19 @@ public class HardenedImageProviderTest {
     assertTrue(result.isEmpty());
   }
 
-  /// Verifies that lookupBySbomId returns empty for a malformed PURL instead of throwing.
+  // Verifies that lookupBySbomId returns empty for a malformed PURL instead of throwing.
   @Test
   void testLookupBySbomIdWithMalformedPurl() {
     assertTrue(provider.lookupBySbomId("not-a-valid-purl").isEmpty());
   }
 
-  /// Verifies that lookupBySbomId returns empty for a null sbomId.
+  // Verifies that lookupBySbomId returns empty for a null sbomId.
   @Test
   void testLookupBySbomIdNull() {
     assertTrue(provider.lookupBySbomId(null).isEmpty());
   }
 
-  /// Verifies that lookupBySbomId returns empty for an OCI PURL with no index match.
+  // Verifies that lookupBySbomId returns empty for an OCI PURL with no index match.
   @Test
   void testLookupBySbomIdNoMatch() {
     // Given an empty index

--- a/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageProviderTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageProviderTest.java
@@ -353,4 +353,58 @@ public class HardenedImageProviderTest {
     assertEquals(1, spyProvider.getIndex().size());
     assertNotNull(spyProvider.lookup("base:1.0"));
   }
+
+  /// Verifies that lookupBySbomId returns the recommendation for a matching OCI PURL.
+  @Test
+  void testLookupBySbomIdMatchingOciPurl() {
+    // Given an index populated with a hardened nginx recommendation
+    IndexedRecommendation rec =
+        IndexedRecommendation.builder()
+            .packageName(new PackageRef(HARDENED_NGINX_PURL))
+            .vulnerabilities(Collections.emptyMap())
+            .sourceName("hardened")
+            .build();
+    provider.getIndex().replaceAll(Map.of("docker.io/library/nginx:1.25", rec));
+
+    // When looking up by OCI PURL with matching repository_url and tag
+    String ociPurl =
+        "pkg:oci/nginx@sha256:def456?repository_url=docker.io%2Flibrary%2Fnginx&tag=1.25";
+    var result = provider.lookupBySbomId(ociPurl);
+
+    // Then the recommendation is returned
+    assertEquals(1, result.size());
+    var entry = result.entrySet().iterator().next();
+    assertEquals(normalized(HARDENED_NGINX_PURL), entry.getValue().packageName().ref());
+    assertEquals("hardened", entry.getValue().sourceName());
+  }
+
+  /// Verifies that lookupBySbomId returns empty for a non-OCI PURL.
+  @Test
+  void testLookupBySbomIdNonOciPurl() {
+    // Given any index state
+    // When looking up by a Maven PURL
+    var result = provider.lookupBySbomId("pkg:maven/io.quarkus/quarkus-core@2.13.5.Final?type=jar");
+
+    // Then the result is empty
+    assertTrue(result.isEmpty());
+  }
+
+  /// Verifies that lookupBySbomId returns empty for a null sbomId.
+  @Test
+  void testLookupBySbomIdNull() {
+    assertTrue(provider.lookupBySbomId(null).isEmpty());
+  }
+
+  /// Verifies that lookupBySbomId returns empty for an OCI PURL with no index match.
+  @Test
+  void testLookupBySbomIdNoMatch() {
+    // Given an empty index
+    // When looking up by an OCI PURL
+    String ociPurl =
+        "pkg:oci/alpine@sha256:abc?repository_url=docker.io%2Flibrary%2Falpine&tag=3.19";
+    var result = provider.lookupBySbomId(ociPurl);
+
+    // Then the result is empty
+    assertTrue(result.isEmpty());
+  }
 }

--- a/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageProviderTest.java
+++ b/src/test/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageProviderTest.java
@@ -389,6 +389,12 @@ public class HardenedImageProviderTest {
     assertTrue(result.isEmpty());
   }
 
+  /// Verifies that lookupBySbomId returns empty for a malformed PURL instead of throwing.
+  @Test
+  void testLookupBySbomIdWithMalformedPurl() {
+    assertTrue(provider.lookupBySbomId("not-a-valid-purl").isEmpty());
+  }
+
   /// Verifies that lookupBySbomId returns empty for a null sbomId.
   @Test
   void testLookupBySbomIdNull() {

--- a/src/test/resources/__files/trustify/hardened-recommendation-response.json
+++ b/src/test/resources/__files/trustify/hardened-recommendation-response.json
@@ -1,15 +1,16 @@
-[
-  {
-    "image_ref": "pkg:oci/hardened-nginx@sha256:abc123?repository_url=registry.example.com%2Fhardened-nginx&tag=1.25",
-    "compare_to": [
-      "docker.io/library/nginx:1.25",
-      "docker.io/library/nginx:1.25-alpine"
-    ]
-  },
-  {
-    "image_ref": "pkg:oci/hardened-python@sha256:def456?repository_url=registry.example.com%2Fhardened-python&tag=3.12",
-    "compare_to": [
-      "docker.io/library/python:3.12"
-    ]
+{
+  "global": {},
+  "images": {
+    "registry.example.com/hardened-nginx:1.25": {
+      "compare_to": [
+        "docker.io/library/nginx:1.25",
+        "docker.io/library/nginx:1.25-alpine"
+      ]
+    },
+    "registry.example.com/hardened-python:3.12": {
+      "compare_to": [
+        "docker.io/library/python:3.12"
+      ]
+    }
   }
-]
+}

--- a/src/test/resources/__files/trustify/hardened-recommendation-response.json
+++ b/src/test/resources/__files/trustify/hardened-recommendation-response.json
@@ -1,0 +1,15 @@
+[
+  {
+    "image_ref": "pkg:oci/hardened-nginx@sha256:abc123?repository_url=registry.example.com%2Fhardened-nginx&tag=1.25",
+    "compare_to": [
+      "docker.io/library/nginx:1.25",
+      "docker.io/library/nginx:1.25-alpine"
+    ]
+  },
+  {
+    "image_ref": "pkg:oci/hardened-python@sha256:def456?repository_url=registry.example.com%2Fhardened-python&tag=3.12",
+    "compare_to": [
+      "docker.io/library/python:3.12"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- Add Camel multicast branch for hardened image recommendations with ProviderRoutePolicy telemetry
- Move OCI PURL resolution logic into `HardenedImageProvider.lookupBySbomId()` for proper class responsibility separation
- Add `@Inject` to `HardenedImageProvider` constructor to fix CDI bean resolution with multiple constructors
- Add integration tests (4) and unit tests (4) covering match/no-match/recommend-false/metrics scenarios

## Test plan
- [x] `HardenedImageIntegrationTest` — 4 WireMock-based `@QuarkusTest` integration tests
- [x] `HardenedImageProviderTest` — 4 new unit tests for `lookupBySbomId` edge cases
- [x] Full test suite passes (294 tests, 0 failures)

Closes TC-4809

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Wire hardened image recommendations into the analysis pipeline and expose them via batch analysis responses.

New Features:
- Add SBOM-based hardened image lookup in HardenedImageProvider using OCI PURLs to resolve base image references.
- Introduce a dedicated Camel route for hardened image recommendations and integrate it into the analysis multicast flow.
- Surface hardened image recommendations in analysis results with provider metrics recorded via ProviderRoutePolicy.

Enhancements:
- Annotate HardenedImageProvider with @Inject constructor injection to ensure proper CDI wiring.
- Refine hardened image index usage by mapping OCI PURLs to Docker-style base image references for recommendation lookup.

Tests:
- Add HardenedImageProvider unit tests covering OCI PURL lookup edge cases and non-OCI scenarios.
- Add WireMock-based HardenedImageIntegrationTest to verify hardened recommendations, recommend=false behavior, unmatched images, and metrics emission.