### PR TITLE
fix(hardened): remove PURL qualifier double-encoding and enable Hummingbird URL

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageResponseHandler.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/providers/trustify/hardened/HardenedImageResponseHandler.java
@@ -17,8 +17,6 @@
 
 package io.github.guacsec.trustifyda.integration.providers.trustify.hardened;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -128,7 +126,7 @@ public class HardenedImageResponseHandler {
     }
 
     String name = path.substring(path.lastIndexOf('/') + 1);
-    String repoUrl = URLEncoder.encode(path, StandardCharsets.UTF_8);
+    String repoUrl = path;
 
     TreeMap<String, String> qualifiers = new TreeMap<>();
     qualifiers.put("repository_url", repoUrl);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,7 +45,7 @@ trustedcontent.recommendation.ubi.mapping.fedora=${trustedcontent.recommendation
 trustedcontent.recommendation.ubi.mapping.amazonlinux=${trustedcontent.recommendation.ubi.purl.ubi9}
 
 # Hardened image recommendation provider (Hummingbird)
-# trustedcontent.recommendation.hardened.url=${HUMMINGBIRD_URL:}
+trustedcontent.recommendation.hardened.url=${HUMMINGBIRD_URL:}
 trustedcontent.recommendation.hardened.refresh-interval=${HUMMINGBIRD_REFRESH_INTERVAL:1h}
 trustedcontent.recommendation.hardened.lock-ttl=${HUMMINGBIRD_LOCK_TTL:5m}
 


### PR DESCRIPTION
## Summary
- Remove redundant `URLEncoder.encode()` in `HardenedImageResponseHandler.containerRefToPackageRef()` — the `PackageURL` constructor already encodes qualifier values, so this was causing double-encoding of the `repository_url` qualifier
- Uncomment the `trustedcontent.recommendation.hardened.url` configuration property to enable Hummingbird integration

## Test plan
- [x] Verify hardened image PURLs contain correctly-encoded `repository_url` qualifiers (no `%25` double-encoding)
- [x] Verify Hummingbird URL config property is active and the provider initializes on startup
- [x] Run existing integration tests for hardened image recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix hardened image recommendation integration by correcting PURL qualifier encoding and enabling the Hummingbird provider configuration.

Bug Fixes:
- Prevent double-encoding of hardened image PURL repository_url qualifiers by avoiding redundant URL encoding.

Enhancements:
- Enable the hardened (Hummingbird) recommendation provider via application configuration.
- Update the generated UI report bundle to align with backend changes.