### PR TITLE
fix(lock): replace invalid SET NX GET with SET NX + GET

### DIFF
--- a/src/main/java/io/github/guacsec/trustifyda/integration/lock/RedisLockService.java
+++ b/src/main/java/io/github/guacsec/trustifyda/integration/lock/RedisLockService.java
@@ -18,48 +18,53 @@
 package io.github.guacsec.trustifyda.integration.lock;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.UUID;
 
 import org.jboss.logging.Logger;
 
-import io.quarkus.redis.datasource.RedisDataSource;
-import io.quarkus.redis.datasource.keys.KeyCommands;
-import io.quarkus.redis.datasource.value.SetArgs;
-import io.quarkus.redis.datasource.value.ValueCommands;
+import io.vertx.mutiny.redis.client.RedisAPI;
+import io.vertx.mutiny.redis.client.Response;
 
 import jakarta.enterprise.context.ApplicationScoped;
 
 /**
- * Redis-based distributed lock implementation. Each instance is identified by a random UUID to
- * ensure only the lock owner can release it. Uses atomic SET NX EX GET to prevent race conditions.
+ * Redis-based distributed lock following the single-instance Redlock pattern. Uses {@code SET NX
+ * EX} for atomic acquisition and a Lua script for atomic owner-checked release.
  */
 @ApplicationScoped
 public class RedisLockService implements LockService {
 
   private static final Logger LOG = Logger.getLogger(RedisLockService.class);
 
-  private final ValueCommands<String, String> lockCommands;
-  private final KeyCommands<String> keyCommands;
+  private static final String RELEASE_SCRIPT =
+      "if redis.call('get', KEYS[1]) == ARGV[1] then "
+          + "return redis.call('del', KEYS[1]) "
+          + "else "
+          + "return 0 "
+          + "end";
+
+  private final RedisAPI redis;
   private final String instanceId = UUID.randomUUID().toString();
 
-  public RedisLockService(RedisDataSource ds) {
-    this.lockCommands = ds.value(String.class);
-    this.keyCommands = ds.key();
+  public RedisLockService(RedisAPI redis) {
+    this.redis = redis;
   }
 
   @Override
   public boolean tryAcquire(String key, Duration ttl) {
-    String previous = lockCommands.setGet(key, instanceId, new SetArgs().nx().ex(ttl));
-    return previous == null;
+    Response response =
+        redis
+            .set(List.of(key, instanceId, "NX", "EX", String.valueOf(ttl.getSeconds())))
+            .await()
+            .indefinitely();
+    return response != null && "OK".equals(response.toString());
   }
 
   @Override
   public void release(String key) {
     try {
-      String currentHolder = lockCommands.get(key);
-      if (instanceId.equals(currentHolder)) {
-        keyCommands.del(key);
-      }
+      redis.eval(List.of(RELEASE_SCRIPT, "1", key, instanceId)).await().indefinitely();
     } catch (Exception e) {
       LOG.warnf(e, "Failed to release distributed lock: %s", key);
     }


### PR DESCRIPTION
## Summary
- Rewrite `RedisLockService` following the [single-instance Redlock pattern](https://redis.io/docs/latest/develop/use/patterns/distributed-locks/)
- Switch from high-level `RedisDataSource` to `RedisAPI` for protocol-level access with proper return values

## Problems fixed
- **`tryAcquire`**: Used `setGet` (`SET NX EX GET`) which Redis rejects — `GET` cannot be combined with `NX`
- **`release`**: Used non-atomic `GET` + `DEL` — if the lock expires between the two calls, another instance's lock gets deleted

## Changes
- **Acquire**: Single `SET key value NX EX ttl` via `RedisAPI.set()`, checking the `OK` response atomically
- **Release**: Lua script via `EVAL` for atomic owner-check-and-delete, preventing race conditions on lock expiry

## References
- [Redis Distributed Locks (Redlock)](https://redis.io/docs/latest/develop/use/patterns/distributed-locks/)
- [Redis SET command — NX/GET incompatibility](https://redis.io/docs/latest/commands/set/)

## Test plan
- [x] All 48 existing tests pass (including `HardenedImageProviderTest`)
- [ ] Deploy to stage and verify `HardenedImageProvider` refresh completes without Redis errors
- [ ] Verify concurrent lock acquisition across replicas

Fixes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)